### PR TITLE
feat(thanos): add needed configuration and resources to deploy Thanos

### DIFF
--- a/eks/local.tf
+++ b/eks/local.tf
@@ -1,0 +1,14 @@
+locals {
+  helm_values = [{
+    kube-prometheus-stack = {
+      prometheus = {
+        serviceAccount = {
+          annotations = {
+            "eks.amazonaws.com/role-arn" = can(var.metrics_archives.bucket_config) ? var.metrics_archives.iam_role_arn : "thanos_not_deployed"
+          }
+        }
+      }
+    }
+  }]
+}
+# TODO replace the condition above with a merge or something!

--- a/eks/local.tf
+++ b/eks/local.tf
@@ -1,14 +1,13 @@
 locals {
-  helm_values = [{
+  helm_values = can(var.metrics_archives.bucket_config) ? [{
     kube-prometheus-stack = {
       prometheus = {
         serviceAccount = {
           annotations = {
-            "eks.amazonaws.com/role-arn" = can(var.metrics_archives.bucket_config) ? var.metrics_archives.iam_role_arn : "thanos_not_deployed"
+            "eks.amazonaws.com/role-arn" = var.metrics_archives.iam_role_arn
           }
         }
       }
     }
-  }]
+  }] : []
 }
-# TODO replace the condition above with a merge or something!

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,14 +1,3 @@
-# resource "kubernetes_service_account" "thanos_s3_serviceaccount" {
-#   metadata {
-#     name      = "thanos-s3-serviceaccount"
-#     namespace = var.namespace
-#     annotations = {
-#       "eks.amazonaws.com/role-arn" = var.metrics_archives.iam_role_arn
-#     }
-#   }
-#   automount_service_account_token = true
-# }
-
 module "kube-prometheus-stack" {
   source = "../"
 

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,0 +1,32 @@
+# resource "kubernetes_service_account" "thanos_s3_serviceaccount" {
+#   metadata {
+#     name      = "thanos-s3-serviceaccount"
+#     namespace = var.namespace
+#     annotations = {
+#       "eks.amazonaws.com/role-arn" = var.metrics_archives.iam_role_arn
+#     }
+#   }
+#   automount_service_account_token = true
+# }
+
+module "kube-prometheus-stack" {
+  source = "../"
+
+  cluster_name     = var.cluster_name
+  argocd_namespace = var.argocd_namespace
+  base_domain      = var.base_domain
+  cluster_issuer   = var.cluster_issuer
+  metrics_archives = var.metrics_archives
+
+  prometheus = {
+    oidc = var.prometheus.oidc
+  }
+  alertmanager = {
+    oidc = var.alertmanager.oidc
+  }
+  grafana = {
+    oidc = var.grafana.oidc
+  }
+
+  helm_values = concat(local.helm_values, var.helm_values)
+}

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -5,17 +5,13 @@ module "kube-prometheus-stack" {
   argocd_namespace = var.argocd_namespace
   base_domain      = var.base_domain
   cluster_issuer   = var.cluster_issuer
-  metrics_archives = var.metrics_archives
+  namespace        = var.namespace
+  dependency_ids   = var.dependency_ids
 
-  prometheus = {
-    oidc = var.prometheus.oidc
-  }
-  alertmanager = {
-    oidc = var.alertmanager.oidc
-  }
-  grafana = {
-    oidc = var.grafana.oidc
-  }
+  metrics_archives = var.metrics_archives
+  prometheus       = var.prometheus
+  alertmanager     = var.alertmanager
+  grafana          = var.grafana
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -1,0 +1,21 @@
+output "id" {
+  value = module.kube-prometheus-stack.id
+}
+
+output "grafana_admin_password" {
+  description = "The admin password for Grafana."
+  value       = module.kube-prometheus-stack.grafana_admin_password
+  sensitive   = true
+}
+
+output "grafana_enabled" {
+  value = module.kube-prometheus-stack.grafana_enabled
+}
+
+output "prometheus_enabled" {
+  value = module.kube-prometheus-stack.prometheus_enabled
+}
+
+output "alertmanager_enabled" {
+  value = module.kube-prometheus-stack.alertmanager_enabled
+}

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf

--- a/local.tf
+++ b/local.tf
@@ -210,6 +210,24 @@ locals {
                 },
               ]
             },
+            # Configuration to test the sidecar by reducing TSDB block size
+            # TODO comment these lines when we're done debugging
+            {
+              name = "prometheus"
+              args = concat([
+                "--web.console.templates=/etc/prometheus/consoles",
+                "--web.console.libraries=/etc/prometheus/console_libraries",
+                "--config.file=/etc/prometheus/config_out/prometheus.env.yaml",
+                "--storage.tsdb.path=/prometheus",
+                "--storage.tsdb.retention.time=10d",
+                "--web.enable-lifecycle",
+                "--web.external-url=http://${local.prometheus.domain}",
+                "--web.route-prefix=/",
+                "--web.config.file=/etc/prometheus/web_config/web-config.yaml",
+                "--storage.tsdb.max-block-duration=1h",
+                "--storage.tsdb.min-block-duration=1h",
+              ])
+            }
           ]
           alertingEndpoints = [
             {

--- a/local.tf
+++ b/local.tf
@@ -222,24 +222,6 @@ locals {
                 },
               ]
             },
-            # Configuration to test the sidecar by reducing TSDB block size
-            # TODO comment these lines when we're done debugging
-            {
-              name = "prometheus"
-              args = concat([
-                "--web.console.templates=/etc/prometheus/consoles",
-                "--web.console.libraries=/etc/prometheus/console_libraries",
-                "--config.file=/etc/prometheus/config_out/prometheus.env.yaml",
-                "--storage.tsdb.path=/prometheus",
-                "--storage.tsdb.retention.time=10d",
-                "--web.enable-lifecycle",
-                "--web.external-url=http://${local.prometheus.domain}",
-                "--web.route-prefix=/",
-                "--web.config.file=/etc/prometheus/web_config/web-config.yaml",
-                "--storage.tsdb.max-block-duration=1h",
-                "--storage.tsdb.min-block-duration=1h",
-              ])
-            }
           ]
           alertingEndpoints = [
             {

--- a/local.tf
+++ b/local.tf
@@ -153,7 +153,7 @@ locals {
           ]
         }
         } : null,
-        merge((!local.grafana.enable && var.grafana.additional_data_sources) ? {
+        merge((!local.grafana.enable && local.grafana.additional_data_sources) ? {
           forceDeployDashboards  = true
           forceDeployDatasources = true
           sidecar = {
@@ -342,7 +342,8 @@ locals {
   }]
 
   grafana_defaults = {
-    enable                   = true
+    enable                   = false
+    additional_data_sources  = false
     generic_oauth_extra_args = {}
     domain                   = "grafana.apps.${var.cluster_name}.${var.base_domain}"
     admin_password           = random_password.grafana_admin_password.result

--- a/local.tf
+++ b/local.tf
@@ -104,8 +104,8 @@ locals {
         }
         additionalDataSources = concat(
           [{
-            name = "Prometheus"
-            type = "prometheus"
+            name      = "Prometheus"
+            type      = "prometheus"
             url       = "http://kube-prometheus-stack-prometheus:9090"
             access    = "proxy"
             isDefault = true
@@ -116,8 +116,8 @@ locals {
             }
           }],
           can(var.metrics_archives.bucket_config) ? [{
-            name = "Thanos-${var.cluster_name}"
-            type = "prometheus"
+            name      = "Thanos-${var.cluster_name}"
+            type      = "prometheus"
             url       = "http://thanos-query.thanos:9090"
             access    = "proxy"
             isDefault = false

--- a/local.tf
+++ b/local.tf
@@ -264,6 +264,9 @@ locals {
               port      = 9093
             },
           ]
+          externalLabels = {
+            prometheus = "prometheus-${var.cluster_name}"
+          }
           }, can(var.metrics_archives.bucket_config) ? {
           thanos = {
             objectStorageConfig = {

--- a/local.tf
+++ b/local.tf
@@ -106,8 +106,6 @@ locals {
           [{
             name = "Prometheus"
             type = "prometheus"
-            # TODO fix this 9091 with oauthPassThru
-            # url: http://kube-prometheus-stack-prometheus:9091/
             url       = "http://kube-prometheus-stack-prometheus:9090"
             access    = "proxy"
             isDefault = true

--- a/local.tf
+++ b/local.tf
@@ -145,7 +145,7 @@ locals {
         } : null, {
         enabled = local.grafana.enable
       })
-      prometheus = merge(local.prometheus.enable ? merge({
+      prometheus = merge(local.prometheus.enable ? {
         ingress = {
           enabled = true
           annotations = {
@@ -282,14 +282,13 @@ locals {
             }
           },
         ]
-        }, can(var.metrics_archives.bucket_config) ? {
-        thanosObjectStorageConfig = var.metrics_archives.bucket_config
-        } : null) : null, {
+        } : null, {
         enabled = local.prometheus.enable
         thanosService = {
           enabled = can(var.metrics_archives.bucket_config) ? true : false
         }
-      })
+        }
+      )
     }
   }]
 

--- a/local.tf
+++ b/local.tf
@@ -102,13 +102,13 @@ locals {
             defaultDatasourceEnabled = false
           }
         }
-        additionalDataSources = [
-          {
+        additionalDataSources = concat(
+          [{
             name = "Prometheus"
             type = "prometheus"
             # TODO fix this 9091 with oauthPassThru
             # url: http://kube-prometheus-stack-prometheus:9091/
-            url       = can(var.metrics_archives.bucket_config) ? "http://thanos-query.thanos:9090" : "http://kube-prometheus-stack-prometheus:9090"
+            url       = "http://kube-prometheus-stack-prometheus:9090"
             access    = "proxy"
             isDefault = true
             jsonData = {
@@ -116,8 +116,20 @@ locals {
               tlsAuthWithCACert = false
               oauthPassThru     = true
             }
-          },
-        ]
+          }],
+          can(var.metrics_archives.bucket_config) ? [{
+            name = "Thanos-${var.cluster_name}"
+            type = "prometheus"
+            url       = "http://thanos-query.thanos:9090"
+            access    = "proxy"
+            isDefault = false
+            jsonData = {
+              tlsAuth           = false
+              tlsAuthWithCACert = false
+              oauthPassThru     = true
+            }
+          }] : null
+        )
         ingress = {
           enabled = true
           annotations = {

--- a/local.tf
+++ b/local.tf
@@ -1,7 +1,7 @@
 locals {
   helm_values = [{
     kube-prometheus-stack = {
-      alertmanager = merge(local.alertmanager.enable ? {
+      alertmanager = merge(local.alertmanager.enabled ? {
         alertmanagerSpec = {
           initContainers = [
             {
@@ -12,7 +12,7 @@ locals {
                 "-c",
               ]
               args = [
-              <<-EOT
+                <<-EOT
                 until curl -skL -w "%%{http_code}\\n" "${replace(local.alertmanager.oidc.api_url, "\"", "\\\"")}" -o /dev/null | grep -vq "^\(000\|404\)$"; do echo "waiting for oidc at ${replace(local.alertmanager.oidc.api_url, "\"", "\\\"")}"; sleep 2; done
               EOT
               ]
@@ -74,9 +74,9 @@ locals {
           selfMonitor = false
         }
         } : null, {
-        enabled = local.alertmanager.enable
+        enabled = local.alertmanager.enabled
       })
-      grafana = merge(local.grafana.enable ? {
+      grafana = merge(local.grafana.enabled ? {
         adminPassword = "${replace(local.grafana.admin_password, "\"", "\\\"")}"
         "grafana.ini" = {
           "auth.generic_oauth" = merge({
@@ -153,7 +153,7 @@ locals {
           ]
         }
         } : null,
-        merge((!local.grafana.enable && local.grafana.additional_data_sources) ? {
+        merge((!local.grafana.enabled && local.grafana.additional_data_sources) ? {
           forceDeployDashboards  = true
           forceDeployDatasources = true
           sidecar = {
@@ -188,10 +188,10 @@ locals {
             }] : []
           )
           } : null, {
-          enabled = local.grafana.enable
+          enabled = local.grafana.enabled
         })
       )
-      prometheus = merge(local.prometheus.enable ? {
+      prometheus = merge(local.prometheus.enabled ? {
         ingress = {
           enabled = true
           annotations = {
@@ -227,7 +227,7 @@ locals {
                 "-c",
               ]
               args = [
-              <<-EOT
+                <<-EOT
                 until curl -skL -w "%%{http_code}\\n" "${replace(local.prometheus.oidc.api_url, "\"", "\\\"")}" -o /dev/null | grep -vq "^\(000\|404\)$"; do echo "waiting for oidc at ${replace(local.prometheus.oidc.api_url, "\"", "\\\"")}"; sleep 2; done
               EOT
               ]
@@ -332,7 +332,7 @@ locals {
           },
         ]
         } : null, {
-        enabled = local.prometheus.enable
+        enabled = local.prometheus.enabled
         thanosService = {
           enabled = can(var.metrics_archives.bucket_config) ? true : false
         }
@@ -342,7 +342,7 @@ locals {
   }]
 
   grafana_defaults = {
-    enable                   = false
+    enabled                  = false
     additional_data_sources  = false
     generic_oauth_extra_args = {}
     domain                   = "grafana.apps.${var.cluster_name}.${var.base_domain}"
@@ -355,8 +355,8 @@ locals {
   )
 
   prometheus_defaults = {
-    domain = "prometheus.apps.${var.cluster_name}.${var.base_domain}"
-    enable = true
+    enabled = true
+    domain  = "prometheus.apps.${var.cluster_name}.${var.base_domain}"
   }
 
   prometheus = merge(
@@ -365,8 +365,8 @@ locals {
   )
 
   alertmanager_defaults = {
-    enable = true
-    domain = "alertmanager.apps.${var.cluster_name}.${var.base_domain}"
+    enabled = true
+    domain  = "alertmanager.apps.${var.cluster_name}.${var.base_domain}"
   }
 
   alertmanager = merge(

--- a/main.tf
+++ b/main.tf
@@ -20,12 +20,6 @@ resource "argocd_project" "this" {
       namespace = var.namespace
     }
 
-    # TODO verify if this should be here
-    destination {
-      name      = "in-cluster"
-      namespace = "kube-system"
-    }
-
     orphaned_resources {
       warn = true
     }

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,24 @@ resource "argocd_project" "this" {
   }
 }
 
+# TODO find a way to only deploy this resource if thanos is deployed
+resource "kubernetes_secret" "thanos_s3_bucket_secret" {
+  metadata {
+    name      = "thanos-objectstorage"
+    namespace = var.namespace
+  }
+
+  data = {
+    "thanos.yaml" = yamlencode(
+      can(var.metrics_archives.bucket_config) ? var.metrics_archives.bucket_config : null
+      )
+  }
+
+  depends_on = [
+    resource.argocd_application.this,
+  ]
+}
+
 resource "random_password" "oauth2_cookie_secret" {
   length  = 16
   special = false

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "argocd_project" "this" {
   }
 
   spec {
-    description  = "Kube-prometheus-stack application project"
+    description  = "kube-prometheus-stack application project"
     source_repos = ["https://github.com/camptocamp/devops-stack-module-kube-prometheus-stack.git"]
 
     destination {

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "kubernetes_secret" "thanos_s3_bucket_secret" {
   data = {
     "thanos.yaml" = yamlencode(
       var.metrics_archives.bucket_config
-      )
+    )
   }
 
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,12 @@ resource "argocd_project" "this" {
   }
 }
 
-# TODO find a way to only deploy this resource if thanos is deployed
 resource "kubernetes_secret" "thanos_s3_bucket_secret" {
+  # This count here is nothing more than a way to conditionally deploy this
+  # resource. Although there is no loop inside the resource, if the condition
+  # is true, the resource is deployed because there is exactly one iteration.
+  count = can(var.metrics_archives.bucket_config) ? 1 : 0
+
   metadata {
     name      = "thanos-objectstorage"
     namespace = var.namespace
@@ -45,7 +49,7 @@ resource "kubernetes_secret" "thanos_s3_bucket_secret" {
 
   data = {
     "thanos.yaml" = yamlencode(
-      can(var.metrics_archives.bucket_config) ? var.metrics_archives.bucket_config : null
+      var.metrics_archives.bucket_config
       )
   }
 

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ resource "argocd_project" "this" {
       namespace = var.namespace
     }
 
+    # TODO verify if this should be here
     destination {
       name      = "in-cluster"
       namespace = "kube-system"
@@ -40,7 +41,7 @@ resource "kubernetes_secret" "thanos_s3_bucket_secret" {
   # This count here is nothing more than a way to conditionally deploy this
   # resource. Although there is no loop inside the resource, if the condition
   # is true, the resource is deployed because there is exactly one iteration.
-  count = can(var.metrics_archives.bucket_config) ? 1 : 0
+  count = var.metrics_archives.thanos_enabled ? 1 : 0
 
   metadata {
     name      = "thanos-objectstorage"

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,15 @@ output "grafana_admin_password" {
   value       = local.grafana.admin_password
   sensitive   = true
 }
+
+output "grafana_enabled" {
+  value = local.grafana.enabled
+}
+
+output "prometheus_enabled" {
+  value = local.prometheus.enabled
+}
+
+output "alertmanager_enabled" {
+  value = local.alertmanager.enabled
+}

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "alertmanager" {
 }
 
 variable "metrics_archives" {
-  description = "Metrics archives settings"
+  description = "Thanos S3 bucket settings"
   type        = any
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,5 +59,7 @@ variable "alertmanager" {
 }
 
 variable "metrics_archives" {
-  type = any
+  description = "Metrics archives settings"
+  type        = any
+  default     = {}
 }


### PR DESCRIPTION
This PR integrates the [thanos module](https://github.com/camptocamp/devops-stack-module-thanos) with the kube-prometheus-stack and it goes hand-in-hand with [this PR](https://github.com/camptocamp/devops-stack-module-thanos/pull/2) in the thanos module. It deploys the configuration and resources needed to deploy a Thanos sidecar with Prometheus and then export the metrics to an S3 bucket for persistence.

All these configurations are applied conditionally when a variable  `metrics_archives` is passed on module call. This also means that the kube-prometheus-stack module must depend on the thanos module in the case that we deploy the latter.

The code is mainly adapted to an AWS deployment but is easily adaptable to other deployments, the only thing that needs changing is the bucket configuration (on AWS we use IAM roles and Kubernetes ServiceAccounts to allow pods to connect to the S3 bucket but on other services we might need API and Secret Keys).

Example module call:
```hcl
module "monitoring" {
  source = "git::https://github.com/camptocamp/devops-stack-module-kube-prometheus-stack//eks"

  cluster_name     = module.eks.cluster_name
  argocd_namespace = local.argocd_namespace
  base_domain      = module.eks.base_domain
  cluster_issuer   = local.cluster_issuer

  metrics_archives = module.thanos.metrics_archives

  prometheus = {
    oidc = module.oidc.oidc
  }
  alertmanager = {
    oidc = module.oidc.oidc
  }
  grafana = {
    enable = false
    additional_data_sources = true
  }

  depends_on = [module.argocd_bootstrap, module.thanos]
}
```