### PR TITLE
chore(azure)!: delete useless resource group variable and clean up

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,6 +148,10 @@ Description: The admin password for Grafana.
 
 Description: n/a
 
+==== [[output_helm_values]] <<output_helm_values,helm_values>>
+
+Description: n/a
+
 ==== [[output_id]] <<output_id,id>>
 
 Description: n/a
@@ -273,6 +277,7 @@ Description: n/a
 |[[output_alertmanager_enabled]] <<output_alertmanager_enabled,alertmanager_enabled>> |n/a
 |[[output_grafana_admin_password]] <<output_grafana_admin_password,grafana_admin_password>> |The admin password for Grafana.
 |[[output_grafana_enabled]] <<output_grafana_enabled,grafana_enabled>> |n/a
+|[[output_helm_values]] <<output_helm_values,helm_values>> |n/a
 |[[output_id]] <<output_id,id>> |n/a
 |[[output_prometheus_enabled]] <<output_prometheus_enabled,prometheus_enabled>> |n/a
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -24,7 +24,7 @@ Version:
 The following resources are used by this module:
 
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.kube_prometheus_stack_prometheus] (resource)
-- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.this] (data source)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] (data source)
 
 === Required Inputs
 
@@ -51,12 +51,6 @@ Type: `string`
 ==== [[input_node_resource_group_name]] <<input_node_resource_group_name,node_resource_group_name>>
 
 Description: The Resource Group of the Managed Kubernetes Cluster.
-
-Type: `string`
-
-==== [[input_resource_group_name]] <<input_resource_group_name,resource_group_name>>
-
-Description: n/a
 
 Type: `string`
 
@@ -165,7 +159,7 @@ No outputs.
 |===
 |Name |Type
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.kube_prometheus_stack_prometheus] |resource
-|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.this] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] |data source
 |===
 
 = Inputs
@@ -244,12 +238,6 @@ No outputs.
 |`any`
 |`{}`
 |no
-
-|[[input_resource_group_name]] <<input_resource_group_name,resource_group_name>>
-|n/a
-|`string`
-|n/a
-|yes
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -1,4 +1,4 @@
-variable "cluster_resource_group_name" {
-    description = "The Resource Group for the kube-prometheus-stack managed identity creation."
-    type = string
+variable "node_resource_group_name" {
+  description = "The Resource Group of the Managed Kubernetes Cluster."
+  type        = string
 }

--- a/aks/local.tf
+++ b/aks/local.tf
@@ -4,7 +4,7 @@ locals {
       prometheus = {
         azureIdentity = {
           resourceID = azurerm_user_assigned_identity.kube_prometheus_stack_prometheus.id
-          clientID = azurerm_user_assigned_identity.kube_prometheus_stack_prometheus.client_id
+          clientID   = azurerm_user_assigned_identity.kube_prometheus_stack_prometheus.client_id
         }
         prometheusSpec = {
           podMetadata = {

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,10 +1,10 @@
-data "azurerm_resource_group" "this" {
-  name = var.cluster_resource_group_name
+data "azurerm_resource_group" "node_resource_group" {
+  name = var.node_resource_group_name
 }
 
 resource "azurerm_user_assigned_identity" "kube_prometheus_stack_prometheus" {
-  resource_group_name = data.azurerm_resource_group.this.name
-  location            = data.azurerm_resource_group.this.location
+  resource_group_name = data.azurerm_resource_group.node_resource_group.name
+  location            = data.azurerm_resource_group.node_resource_group.location
   name                = "kube-prometheus-stack-prometheus"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,5 +21,5 @@ output "alertmanager_enabled" {
 }
 
 output "helm_values" {
- value = data.utils_deep_merge_yaml.values.output
+  value = data.utils_deep_merge_yaml.values.output
 }


### PR DESCRIPTION
:warning: **BREAKING CHANGE**
We only need to pass the managed cluster resource group name as a module input to create "kube-prometheus-stack-prometheus" managed identity, the other resource group variable is useless.
Also, the name of the data source that we use to request the resource group information is made more explicit.
And finally, terraform fmt.