### PR TITLE
feat(Azure): add missing ID output

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -130,7 +130,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.1"`
+Default: `"v1.0.0-alpha.2"`
 
 === Outputs
 
@@ -264,7 +264,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.1"`
+|`"v1.0.0-alpha.2"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -144,11 +144,15 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.1"`
+Default: `"v1.0.0-alpha.2"`
 
 === Outputs
 
-No outputs.
+The following outputs are exported:
+
+==== [[output_id]] <<output_id,id>>
+
+Description: n/a
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 
@@ -274,8 +278,16 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.1"`
+|`"v1.0.0-alpha.2"`
 |no
 
+|===
+
+= Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_id]] <<output_id,id>> |n/a
 |===
 // END_TF_TABLES

--- a/aks/output.tf
+++ b/aks/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = module.kube-prometheus-stack.id
+}

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -133,7 +133,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.1"`
+Default: `"v1.0.0-alpha.2"`
 
 === Outputs
 
@@ -260,7 +260,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.1"`
+|`"v1.0.0-alpha.2"`
 |no
 
 |===


### PR DESCRIPTION
This output is present in all cloud provider modules except Azure. This output is used to manage dependencies between modules.
Tested on Azure, no further tests needed.