### PR TITLE
feat(kind): allow insecure access to storage endpoint

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -155,7 +155,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.4"`
+Default: `"v1.0.0-alpha.6"`
 
 === Outputs
 
@@ -316,7 +316,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.4"`
+|`"v1.0.0-alpha.6"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -168,7 +168,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.4"`
+Default: `"v1.0.0-alpha.6"`
 
 === Outputs
 
@@ -328,7 +328,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.4"`
+|`"v1.0.0-alpha.6"`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -157,7 +157,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.4"`
+Default: `"v1.0.0-alpha.6"`
 
 === Outputs
 
@@ -310,7 +310,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.4"`
+|`"v1.0.0-alpha.6"`
 |no
 
 |===

--- a/kind/extra-variables.tf
+++ b/kind/extra-variables.tf
@@ -5,6 +5,7 @@ variable "metrics_storage" {
     endpoint   = string
     access_key = string
     secret_key = string
+    insecure   = optional(bool, false)
   })
   default = null
 }


### PR DESCRIPTION
**Summary**
Thanos sidecar can now optionally access storage endpoint in insecure mode. Use `insecure` attribute of `metrics_storage` input.

**Test platform**
- [ ] Azure
- [ ] AWS
- [x] KIND