### PR TITLE
feat(azure)!: use managed identity to access object storage

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -170,7 +170,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.7"`
+Default: `"v1.0.0"`
 
 === Outputs
 
@@ -337,7 +337,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.7"`
+|`"v1.0.0"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -21,8 +21,10 @@ Version:
 
 The following resources are used by this module:
 
-- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.kube_prometheus_stack_prometheus] (resource)
-- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] (data source)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.contributor] (resource)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.prometheus] (resource)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node] (data source)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] (data source)
 
 === Required Inputs
 
@@ -43,12 +45,6 @@ Type: `string`
 ==== [[input_cluster_name]] <<input_cluster_name,cluster_name>>
 
 Description: n/a
-
-Type: `string`
-
-==== [[input_node_resource_group_name]] <<input_node_resource_group_name,node_resource_group_name>>
-
-Description: The Resource Group of the Managed Kubernetes Cluster.
 
 Type: `string`
 
@@ -128,9 +124,10 @@ Type:
 [source,hcl]
 ----
 object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container                     = string
+    storage_account               = string
+    managed_identity_node_rg_name = optional(string, null)
+    storage_account_key           = optional(string, null)
   })
 ----
 
@@ -166,7 +163,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.7"`
+Default: `"v1.0.0"`
 
 === Outputs
 
@@ -200,8 +197,10 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Type
-|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.kube_prometheus_stack_prometheus] |resource
-|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.contributor] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.prometheus] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] |data source
 |===
 
 = Inputs
@@ -290,9 +289,10 @@ object({
 [source]
 ----
 object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container                     = string
+    storage_account               = string
+    managed_identity_node_rg_name = optional(string, null)
+    storage_account_key           = optional(string, null)
   })
 ----
 
@@ -311,12 +311,6 @@ object({
 |`"kube-prometheus-stack"`
 |no
 
-|[[input_node_resource_group_name]] <<input_node_resource_group_name,node_resource_group_name>>
-|The Resource Group of the Managed Kubernetes Cluster.
-|`string`
-|n/a
-|yes
-
 |[[input_prometheus]] <<input_prometheus,prometheus>>
 |Prometheus settings
 |`any`
@@ -326,7 +320,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.7"`
+|`"v1.0.0"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -118,7 +118,7 @@ Default: `[]`
 
 ==== [[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
 
-Description: Azure Blob Storage configuration values for the storage container where the archived metrics will be stored.
+Description: Azure Blob Storage configuration for metric archival.
 
 Type:
 [source,hcl]
@@ -283,7 +283,7 @@ object({
 |no
 
 |[[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
-|Azure Blob Storage configuration values for the storage container where the archived metrics will be stored.
+|Azure Blob Storage configuration for metric archival.
 |
 
 [source]

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -1,14 +1,23 @@
-variable "node_resource_group_name" {
-  description = "The Resource Group of the Managed Kubernetes Cluster."
-  type        = string
-}
-
 variable "metrics_storage" {
   description = "Azure Blob Storage configuration values for the storage container where the archived metrics will be stored."
   type = object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container       = string
+    storage_account = string
+    use_managed_identity = object({
+      enabled      = bool
+      node_rg_name = optional(string, null)
+    })
+    storage_account_key = optional(string, null)
   })
+
+  validation {
+    condition     = try(var.metrics_storage.use_managed_identity.enabled == (var.metrics_storage.storage_account_key == null), true)
+    error_message = "Setting storage_account_key and using a managed identity are mutually exclusive."
+  }
+
+  validation {
+    condition     = try(var.metrics_storage.use_managed_identity.enabled == (var.metrics_storage.use_managed_identity.node_rg_name != null), true)
+    error_message = "use_managed_identity.node_rg_name must only be set when using a managed identity."
+  }
   default = null
 }

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -1,23 +1,16 @@
 variable "metrics_storage" {
   description = "Azure Blob Storage configuration values for the storage container where the archived metrics will be stored."
   type = object({
-    container       = string
-    storage_account = string
-    use_managed_identity = object({
-      enabled      = bool
-      node_rg_name = optional(string, null)
-    })
-    storage_account_key = optional(string, null)
+    container                     = string
+    storage_account               = string
+    managed_identity_node_rg_name = optional(string, null)
+    storage_account_key           = optional(string, null)
   })
 
   validation {
-    condition     = try(var.metrics_storage.use_managed_identity.enabled == (var.metrics_storage.storage_account_key == null), true)
-    error_message = "Setting storage_account_key and using a managed identity are mutually exclusive."
+    condition     = try((var.metrics_storage.managed_identity_node_rg_name == null) != (var.metrics_storage.storage_account_key == null), true)
+    error_message = "You must set one (and only one) of these attributes: managed_identity_node_rg_name, storage_account_key."
   }
 
-  validation {
-    condition     = try(var.metrics_storage.use_managed_identity.enabled == (var.metrics_storage.use_managed_identity.node_rg_name != null), true)
-    error_message = "use_managed_identity.node_rg_name must only be set when using a managed identity."
-  }
   default = null
 }

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -1,5 +1,5 @@
 variable "metrics_storage" {
-  description = "Azure Blob Storage configuration values for the storage container where the archived metrics will be stored."
+  description = "Azure Blob Storage configuration for metric archival."
   type = object({
     container                     = string
     storage_account               = string

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -1,8 +1,10 @@
 locals {
+  use_managed_identity = try(var.metrics_storage.managed_identity_node_rg_name != null, false)
+
   helm_values = [{
     kube-prometheus-stack = {
       prometheus = {
-        prometheusSpec = merge(try(var.metrics_storage.use_managed_identity.enabled, false) ? {
+        prometheusSpec = merge(local.use_managed_identity ? {
           podMetadata = {
             labels = {
               aadpodidbinding = "prometheus"
@@ -11,7 +13,7 @@ locals {
         } : null, {})
       }
     }
-    }, try(var.metrics_storage.use_managed_identity.enabled, false) ? {
+    }, local.use_managed_identity ? {
     azureIdentity = {
       resourceID = azurerm_user_assigned_identity.prometheus[0].id
       clientID   = azurerm_user_assigned_identity.prometheus[0].client_id

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,11 +1,30 @@
-data "azurerm_resource_group" "node_resource_group" {
-  name = var.node_resource_group_name
+data "azurerm_resource_group" "node" {
+  count = try(var.metrics_storage.use_managed_identity.enabled, false) ? 1 : 0
+
+  name = var.metrics_storage.use_managed_identity.node_rg_name
 }
 
-resource "azurerm_user_assigned_identity" "kube_prometheus_stack_prometheus" {
-  resource_group_name = data.azurerm_resource_group.node_resource_group.name
-  location            = data.azurerm_resource_group.node_resource_group.location
-  name                = "kube-prometheus-stack-prometheus"
+data "azurerm_storage_container" "container" {
+  count = try(var.metrics_storage.use_managed_identity.enabled, false) ? 1 : 0
+
+  name                 = var.metrics_storage.container
+  storage_account_name = var.metrics_storage.storage_account
+}
+
+resource "azurerm_user_assigned_identity" "prometheus" {
+  count = try(var.metrics_storage.use_managed_identity.enabled, false) ? 1 : 0
+
+  resource_group_name = data.azurerm_resource_group.node[0].name
+  location            = data.azurerm_resource_group.node[0].location
+  name                = "prometheus"
+}
+
+resource "azurerm_role_assignment" "contributor" {
+  count = try(var.metrics_storage.use_managed_identity.enabled, false) ? 1 : 0
+
+  scope                = data.azurerm_storage_container.container[0].resource_manager_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.prometheus[0].principal_id
 }
 
 module "kube-prometheus-stack" {
@@ -24,7 +43,12 @@ module "kube-prometheus-stack" {
   alertmanager = var.alertmanager
   grafana      = var.grafana
 
-  metrics_storage_main = var.metrics_storage != null ? { storage_config = merge({ type = "AZURE" }, { config = var.metrics_storage }) } : null
+  metrics_storage_main = var.metrics_storage != null ? { storage_config = merge({ type = "AZURE" }, { config = merge({
+    container       = var.metrics_storage.container
+    storage_account = var.metrics_storage.storage_account
+    }, var.metrics_storage.use_managed_identity.enabled ? null : {
+    storage_account_key = var.metrics_storage.storage_account_key
+  }) }) } : null
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/charts/kube-prometheus-stack/templates/azureidentity.yaml
+++ b/charts/kube-prometheus-stack/templates/azureidentity.yaml
@@ -1,11 +1,11 @@
-{{- if index $.Values "kube-prometheus-stack" "prometheus" "azureIdentity" }}
+{{- with .Values.azureIdentity }}
 ---
 apiVersion: aadpodidentity.k8s.io/v1
 kind: AzureIdentity
 metadata:
-  name: kube-prometheus-stack-prometheus
+  name: prometheus
 spec:
   type: 0
-  resourceID: {{ index $.Values "kube-prometheus-stack" "prometheus" "azureIdentity" "resourceID" }}
-  clientID: {{ index $.Values "kube-prometheus-stack" "prometheus" "azureIdentity" "clientID" }}
+  resourceID: {{ .resourceID }}
+  clientID: {{ .clientID }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/azureidentitybinding.yaml
+++ b/charts/kube-prometheus-stack/templates/azureidentitybinding.yaml
@@ -1,11 +1,10 @@
-{{- if index $.Values "kube-prometheus-stack" "prometheus" "azureIdentity" }}
+{{- with .Values.azureIdentity }}
 ---
 apiVersion: aadpodidentity.k8s.io/v1
 kind: AzureIdentityBinding
 metadata:
-  name: kube-prometheus-stack-prometheus-binding
+  name: prometheus-binding
 spec:
-  azureIdentity: kube-prometheus-stack-prometheus
-  selector: kube-prometheus-stack-prometheus
-  weight: 0
+  azureIdentity: prometheus
+  selector: prometheus
 {{- end }}

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -147,7 +147,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.7"`
+Default: `"v1.0.0"`
 
 === Outputs
 
@@ -300,7 +300,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.7"`
+|`"v1.0.0"`
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -149,7 +149,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.7"`
+Default: `"v1.0.0"`
 
 === Outputs
 
@@ -304,7 +304,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.7"`
+|`"v1.0.0"`
 |no
 
 |===


### PR DESCRIPTION
## Description of the changes
User can now choose between key-based and identity-based access to object storage by thanos sidecar.
The variable `metrics_storage` is refactored as follow:
```hcl
metrics_storage = {
  container       = azurerm_storage_container.metrics.name
  storage_account = azurerm_storage_account.metrics.name

  managed_identity_node_rg_name = module.cluster.node_resource_group # Unset when using account key.

  storage_account_key = azurerm_storage_account.metrics.primary_access_key # Unset when using a managed identity
}
```
**Imporant:** when using identity-based access, aad-pod-identity must be declared as module dependency.

## Breaking change

- [ ] No
- [ ] Yes (in the Helm chart(s))
- [x] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)