### PR TITLE
fix(eks): terraform error when var.metrics_storage is null

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -82,7 +82,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -271,7 +271,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -26,15 +26,15 @@ Below you will only find the technical reference automatically generated from th
 
 The following providers are used by this module:
 
+- [[provider_random]] <<provider_random,random>>
+
 - [[provider_null]] <<provider_null,null>>
+
+- [[provider_argocd]] <<provider_argocd,argocd>>
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>>
 
-- [[provider_random]] <<provider_random,random>>
-
 - [[provider_utils]] <<provider_utils,utils>>
-
-- [[provider_argocd]] <<provider_argocd,argocd>>
 
 === Resources
 
@@ -222,11 +222,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |n/a
-|[[provider_null]] <<provider_null,null>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |n/a
+|[[provider_random]] <<provider_random,random>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
+|[[provider_null]] <<provider_null,null>> |n/a
 |===
 
 = Resources

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -254,7 +254,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -59,7 +59,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -234,7 +234,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  helm_values = var.metrics_storage != null ? ( var.metrics_storage.iam_role_arn != "" ? [{
+  helm_values = var.metrics_storage != null ? [{
     kube-prometheus-stack = {
       prometheus = {
         serviceAccount = {
@@ -9,5 +9,5 @@ locals {
         }
       }
     }
-  }] : []) : []
+  }] : []
 }

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  helm_values = (var.metrics_storage.iam_role_arn != "") ? [{
+  helm_values = var.metrics_storage != null ? ( var.metrics_storage.iam_role_arn != "" ? [{
     kube-prometheus-stack = {
       prometheus = {
         serviceAccount = {
@@ -9,5 +9,5 @@ locals {
         }
       }
     }
-  }] : []
+  }] : []) : []
 }

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -238,7 +238,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>


### PR DESCRIPTION
## Description of the changes

Fix a terraform error that would make the plan/apply fail when var.metrics_storage is null.

## Breaking change

NO

## Tests executed on which distribution(s)

- [x] EKS (AWS)
