### PR TITLE
fix(grafana): ignore self-signed certificates for Grafana

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -222,11 +222,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |n/a
 |[[provider_random]] <<provider_random,random>> |n/a
+|[[provider_null]] <<provider_null,null>> |n/a
+|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |n/a
 |[[provider_argocd]] <<provider_argocd,argocd>> |n/a
-|[[provider_null]] <<provider_null,null>> |n/a
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -26,15 +26,15 @@ Below you will only find the technical reference automatically generated from th
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>>
-
 - [[provider_null]] <<provider_null,null>>
-
-- [[provider_argocd]] <<provider_argocd,argocd>>
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>>
 
+- [[provider_random]] <<provider_random,random>>
+
 - [[provider_utils]] <<provider_utils,utils>>
+
+- [[provider_argocd]] <<provider_argocd,argocd>>
 
 === Resources
 
@@ -82,7 +82,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.2.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -224,9 +224,9 @@ Description: n/a
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |n/a
 |[[provider_null]] <<provider_null,null>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
 |===
 
 = Resources
@@ -271,7 +271,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.2.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -26,15 +26,15 @@ Below you will only find the technical reference automatically generated from th
 
 The following providers are used by this module:
 
+- [[provider_random]] <<provider_random,random>>
+
 - [[provider_null]] <<provider_null,null>>
+
+- [[provider_argocd]] <<provider_argocd,argocd>>
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>>
 
-- [[provider_random]] <<provider_random,random>>
-
 - [[provider_utils]] <<provider_utils,utils>>
-
-- [[provider_argocd]] <<provider_argocd,argocd>>
 
 === Resources
 
@@ -222,11 +222,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |n/a
-|[[provider_null]] <<provider_null,null>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |n/a
+|[[provider_random]] <<provider_random,random>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
+|[[provider_null]] <<provider_null,null>> |n/a
 |===
 
 = Resources

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.2.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -254,7 +254,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.2.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -59,7 +59,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.2.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -234,7 +234,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.2.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.2.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -238,7 +238,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.2.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/locals.tf
+++ b/locals.tf
@@ -327,7 +327,7 @@ locals {
   }]
 
   grafana_defaults = {
-    enabled                  = true
+    enabled                  = false
     additional_data_sources  = false
     generic_oauth_extra_args = {}
     domain                   = "grafana.apps.${var.cluster_name}.${var.base_domain}"

--- a/locals.tf
+++ b/locals.tf
@@ -88,7 +88,7 @@ locals {
             auth_url                 = "${replace(local.grafana.oidc.oauth_url, "\"", "\\\"")}"
             token_url                = "${replace(local.grafana.oidc.token_url, "\"", "\\\"")}"
             api_url                  = "${replace(local.grafana.oidc.api_url, "\"", "\\\"")}"
-            tls_skip_verify_insecure = var.cluster_issuer == "ca-issuer" ? true : false
+            tls_skip_verify_insecure = var.cluster_issuer == "ca-issuer" || var.cluster_issuer == "letsencrypt-staging"
           }, local.grafana.generic_oauth_extra_args)
           users = {
             auto_assign_org_role = "Editor"

--- a/locals.tf
+++ b/locals.tf
@@ -80,14 +80,15 @@ locals {
         adminPassword = "${replace(local.grafana.admin_password, "\"", "\\\"")}"
         "grafana.ini" = {
           "auth.generic_oauth" = merge({
-            enabled       = true
-            allow_sign_up = true
-            client_id     = "${replace(local.grafana.oidc.client_id, "\"", "\\\"")}"
-            client_secret = "${replace(local.grafana.oidc.client_secret, "\"", "\\\"")}"
-            scopes        = "openid profile email"
-            auth_url      = "${replace(local.grafana.oidc.oauth_url, "\"", "\\\"")}"
-            token_url     = "${replace(local.grafana.oidc.token_url, "\"", "\\\"")}"
-            api_url       = "${replace(local.grafana.oidc.api_url, "\"", "\\\"")}"
+            enabled                  = true
+            allow_sign_up            = true
+            client_id                = "${replace(local.grafana.oidc.client_id, "\"", "\\\"")}"
+            client_secret            = "${replace(local.grafana.oidc.client_secret, "\"", "\\\"")}"
+            scopes                   = "openid profile email"
+            auth_url                 = "${replace(local.grafana.oidc.oauth_url, "\"", "\\\"")}"
+            token_url                = "${replace(local.grafana.oidc.token_url, "\"", "\\\"")}"
+            api_url                  = "${replace(local.grafana.oidc.api_url, "\"", "\\\"")}"
+            tls_skip_verify_insecure = var.cluster_issuer == "ca-issuer" ? true : false
           }, local.grafana.generic_oauth_extra_args)
           users = {
             auto_assign_org_role = "Editor"
@@ -326,7 +327,7 @@ locals {
   }]
 
   grafana_defaults = {
-    enabled                  = false
+    enabled                  = true
     additional_data_sources  = false
     generic_oauth_extra_args = {}
     domain                   = "grafana.apps.${var.cluster_name}.${var.base_domain}"


### PR DESCRIPTION
## Description of the changes

I added a way to skip TLS validation of the OIDC authentication of Grafana when using `ca-issuer` as a Certificate Authority.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s))
- [ ] Yes (in the module itself)

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)