### PR TITLE
fix: services customization

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -82,7 +82,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -271,7 +271,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -26,15 +26,15 @@ Below you will only find the technical reference automatically generated from th
 
 The following providers are used by this module:
 
+- [[provider_random]] <<provider_random,random>>
+
 - [[provider_null]] <<provider_null,null>>
+
+- [[provider_argocd]] <<provider_argocd,argocd>>
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>>
 
-- [[provider_random]] <<provider_random,random>>
-
 - [[provider_utils]] <<provider_utils,utils>>
-
-- [[provider_argocd]] <<provider_argocd,argocd>>
 
 === Resources
 
@@ -222,11 +222,11 @@ Description: n/a
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |n/a
 |[[provider_null]] <<provider_null,null>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |n/a
+|[[provider_random]] <<provider_random,random>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
 |===
 
 = Resources

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -254,7 +254,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -59,7 +59,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -234,7 +234,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  helm_values = var.metrics_storage != null ? ( var.metrics_storage.iam_role_arn != "" ? [{
+  helm_values = var.metrics_storage != null ? [{
     kube-prometheus-stack = {
       prometheus = {
         serviceAccount = {
@@ -9,5 +9,5 @@ locals {
         }
       }
     }
-  }] : []) : []
+  }] : []
 }

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  helm_values = (var.metrics_storage.iam_role_arn != "") ? [{
+  helm_values = var.metrics_storage != null ? ( var.metrics_storage.iam_role_arn != "" ? [{
     kube-prometheus-stack = {
       prometheus = {
         serviceAccount = {
@@ -9,5 +9,5 @@ locals {
         }
       }
     }
-  }] : []
+  }] : []) : []
 }

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -238,7 +238,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/locals.tf
+++ b/locals.tf
@@ -24,7 +24,7 @@ locals {
               name  = "alertmanager-proxy"
               ports = [
                 {
-                  name          = "web"
+                  name          = "proxy"
                   containerPort = 9095
                 },
               ]
@@ -53,6 +53,7 @@ locals {
             "ingress.kubernetes.io/ssl-redirect"               = "true"
             "kubernetes.io/ingress.allow-http"                 = "false"
           }
+          servicePort = "9095"
           hosts = [
             "${local.alertmanager.domain}",
             "alertmanager.apps.${var.base_domain}"
@@ -68,10 +69,13 @@ locals {
           ]
         }
         service = {
-          targetPort = 9095
-        }
-        serviceMonitor = {
-          selfMonitor = false
+          additionalPorts = [
+            {
+              name       = "proxy"
+              port       = 9095
+              targetPort = 9095
+            },
+          ]
         }
         } : null, {
         enabled = local.alertmanager.enabled
@@ -186,6 +190,7 @@ locals {
             "ingress.kubernetes.io/ssl-redirect"               = "true"
             "kubernetes.io/ingress.allow-http"                 = "false"
           }
+          servicePort = "9091"
           hosts = [
             "${local.prometheus.domain}",
             "prometheus.apps.${var.base_domain}",
@@ -201,7 +206,6 @@ locals {
           ]
         }
         prometheusSpec = merge({
-          portName = "proxy"
           initContainers = [
             {
               name  = "wait-for-oidc"
@@ -260,61 +264,14 @@ locals {
           }
         } : null)
         service = {
-          port       = 9091
-          targetPort = 9091
           additionalPorts = [
             {
-              name       = "web"
-              port       = 9090
-              targetPort = 9090
+              name       = "proxy"
+              port       = 9091
+              targetPort = 9091
             },
           ]
         }
-        serviceMonitor = {
-          selfMonitor = false
-        }
-        additionalPodMonitors = [
-          {
-            name = "alertmanager"
-            podMetricsEndpoints = [
-              {
-                path       = "/metrics"
-                targetPort = 9093
-              },
-            ]
-            namespaceSelector = {
-              matchNames = [
-                "kube-prometheus-stack"
-              ]
-            }
-            selector = {
-              matchLabels = {
-                alertmanager = "kube-prometheus-stack-alertmanager"
-                app          = "alertmanager"
-              }
-            }
-          },
-          {
-            name = "prometheus"
-            podMetricsEndpoints = [
-              {
-                path       = "/metrics"
-                targetPort = 9090
-              },
-            ]
-            namespaceSelector = {
-              matchNames = [
-                "kube-prometheus-stack"
-              ]
-            }
-            selector = {
-              matchLabels = {
-                prometheus = "kube-prometheus-stack-prometheus"
-                app        = "prometheus"
-              }
-            }
-          },
-        ]
         } : null, {
         enabled = local.prometheus.enabled
         thanosService = {


### PR DESCRIPTION
## Description of the changes

improve services / monitoring customization
    
Configure an additional service port for oauth-proxy on prometheus and alertmanager, instead of modifying the default port. This seems more in line with the chart's design, allows us to:
    
- keep "selfMonitor" enabled (ServiceMonitors built in the chart)
- get rid of the custom monitoring targets
- fix the prometheus and alertmanager dashboards that come with the chart

## Breaking change

- [x] It shouldn't

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [x] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)