### PR TITLE
fix: improve services / monitoring customization

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -24,7 +24,7 @@ locals {
               name  = "alertmanager-proxy"
               ports = [
                 {
-                  name          = "web"
+                  name          = "proxy"
                   containerPort = 9095
                 },
               ]
@@ -53,6 +53,7 @@ locals {
             "ingress.kubernetes.io/ssl-redirect"               = "true"
             "kubernetes.io/ingress.allow-http"                 = "false"
           }
+          servicePort = "9095"
           hosts = [
             "${local.alertmanager.domain}",
             "alertmanager.apps.${var.base_domain}"
@@ -68,10 +69,13 @@ locals {
           ]
         }
         service = {
-          targetPort = 9095
-        }
-        serviceMonitor = {
-          selfMonitor = false
+          additionalPorts = [
+            {
+              name       = "proxy"
+              port       = 9095
+              targetPort = 9095
+            },
+          ]
         }
         } : null, {
         enabled = local.alertmanager.enabled
@@ -186,6 +190,7 @@ locals {
             "ingress.kubernetes.io/ssl-redirect"               = "true"
             "kubernetes.io/ingress.allow-http"                 = "false"
           }
+          servicePort = "9091"
           hosts = [
             "${local.prometheus.domain}",
             "prometheus.apps.${var.base_domain}",
@@ -201,7 +206,6 @@ locals {
           ]
         }
         prometheusSpec = merge({
-          portName = "proxy"
           initContainers = [
             {
               name  = "wait-for-oidc"
@@ -260,61 +264,14 @@ locals {
           }
         } : null)
         service = {
-          port       = 9091
-          targetPort = 9091
           additionalPorts = [
             {
-              name       = "web"
-              port       = 9090
-              targetPort = 9090
+              name       = "proxy"
+              port       = 9091
+              targetPort = 9091
             },
           ]
         }
-        serviceMonitor = {
-          selfMonitor = false
-        }
-        additionalPodMonitors = [
-          {
-            name = "alertmanager"
-            podMetricsEndpoints = [
-              {
-                path       = "/metrics"
-                targetPort = 9093
-              },
-            ]
-            namespaceSelector = {
-              matchNames = [
-                "kube-prometheus-stack"
-              ]
-            }
-            selector = {
-              matchLabels = {
-                alertmanager = "kube-prometheus-stack-alertmanager"
-                app          = "alertmanager"
-              }
-            }
-          },
-          {
-            name = "prometheus"
-            podMetricsEndpoints = [
-              {
-                path       = "/metrics"
-                targetPort = 9090
-              },
-            ]
-            namespaceSelector = {
-              matchNames = [
-                "kube-prometheus-stack"
-              ]
-            }
-            selector = {
-              matchLabels = {
-                prometheus = "kube-prometheus-stack-prometheus"
-                app        = "prometheus"
-              }
-            }
-          },
-        ]
         } : null, {
         enabled = local.prometheus.enabled
         thanosService = {


### PR DESCRIPTION
## Description of the changes

Configure an additional service port for oauth-proxy on prometheus and alertmanager, instead of modifying the default port. This seems more in line with the chart's design, allows us to:

- keep "selfMonitor" enabled (ServiceMonitors built in the chart)
- get rid of the custom monitoring targets
- make the prometheus and alertmanager dashboards that come with the chart work as expected

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [x] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)