### PR TITLE
feat/fix: add SKS variant and standardize bucket configuration on other variants

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -8,4 +8,4 @@ jobs:
   terraform-docs:
     uses: camptocamp/devops-stack/.github/workflows/modules-terraform-docs.yaml@main
     with:
-      variants: "aks,eks,kind"
+      variants: "aks,eks,kind,sks"

--- a/README.adoc
+++ b/README.adoc
@@ -38,15 +38,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_helm]] <<provider_helm,helm>>
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
@@ -245,10 +245,10 @@ Description: The admin password for Grafana.
 |===
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_helm]] <<provider_helm,helm>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_null]] <<provider_null,null>> |>= 3
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -38,6 +38,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
@@ -47,8 +49,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_helm]] <<provider_helm,helm>>
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 

--- a/README.adoc
+++ b/README.adoc
@@ -38,17 +38,17 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_helm]] <<provider_helm,helm>>
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -100,7 +100,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -244,12 +244,12 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_helm]] <<provider_helm,helm>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -296,7 +296,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -89,7 +89,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -292,7 +292,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -1,16 +1,20 @@
 locals {
   use_managed_identity = try(var.metrics_storage.managed_identity_node_rg_name != null, false)
 
-  metrics_storage = var.metrics_storage != null ? {
+  metrics_storage = var.metrics_storage == null ? null : {
     storage_config = {
       type = "AZURE"
-      config = merge({
-        container       = var.metrics_storage.container
-        storage_account = var.metrics_storage.storage_account
+      config = merge(
+        {
+          container       = var.metrics_storage.container
+          storage_account = var.metrics_storage.storage_account
         },
-      local.use_managed_identity ? null : { storage_account_key = var.metrics_storage.storage_account_key })
+        local.use_managed_identity ? null : {
+          storage_account_key = var.metrics_storage.storage_account_key
+        }
+      )
     }
-  } : null
+  }
 
   helm_values = [{
     kube-prometheus-stack = {

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -2,13 +2,14 @@ locals {
   use_managed_identity = try(var.metrics_storage.managed_identity_node_rg_name != null, false)
 
   metrics_storage = var.metrics_storage != null ? {
-    storage_config = merge({ type = "AZURE" }, {
+    storage_config = {
+      type = "AZURE"
       config = merge({
         container       = var.metrics_storage.container
         storage_account = var.metrics_storage.storage_account
         },
       local.use_managed_identity ? null : { storage_account_key = var.metrics_storage.storage_account_key })
-    })
+    }
   } : null
 
   helm_values = [{

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -1,6 +1,16 @@
 locals {
   use_managed_identity = try(var.metrics_storage.managed_identity_node_rg_name != null, false)
 
+  metrics_storage = var.metrics_storage != null ? {
+    storage_config = merge({ type = "AZURE" }, {
+      config = merge({
+        container       = var.metrics_storage.container
+        storage_account = var.metrics_storage.storage_account
+        },
+      local.use_managed_identity ? null : { storage_account_key = var.metrics_storage.storage_account_key })
+    })
+  } : null
+
   helm_values = [{
     kube-prometheus-stack = {
       prometheus = {

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -44,15 +44,7 @@ module "kube-prometheus-stack" {
   alertmanager = var.alertmanager
   grafana      = var.grafana
 
-  metrics_storage_main = var.metrics_storage == null ? null : {
-    storage_config = merge({ type = "AZURE" }, {
-      config = merge({
-        container       = var.metrics_storage.container
-        storage_account = var.metrics_storage.storage_account
-        },
-      local.use_managed_identity ? null : { storage_account_key = var.metrics_storage.storage_account_key })
-    })
-  }
+  metrics_storage_main = local.metrics_storage
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -73,7 +73,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -256,7 +256,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,4 +1,14 @@
 locals {
+  metrics_storage = var.metrics_storage != null ? {
+    storage_config = {
+      type = "s3"
+      config = {
+        bucket   = "${var.metrics_storage.bucket_id}"
+        endpoint = "s3.${var.metrics_storage.region}.amazonaws.com"
+      }
+    }
+  } : null
+
   helm_values = var.metrics_storage != null ? [{
     kube-prometheus-stack = {
       prometheus = {

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -15,16 +15,7 @@ module "kube-prometheus-stack" {
   alertmanager = var.alertmanager
   grafana      = var.grafana
 
-  metrics_storage_main = var.metrics_storage != null ? {
-    storage_config = merge({
-      type = "s3"
-      }, {
-      config = {
-        bucket   = "${var.metrics_storage.bucket_id}"
-        endpoint = "s3.${var.metrics_storage.region}.amazonaws.com"
-      }
-    })
-  } : null
+  metrics_storage_main = local.metrics_storage
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -51,11 +51,11 @@ Type:
 [source,hcl]
 ----
 object({
-    bucket     = string
-    endpoint   = string
-    access_key = string
-    secret_key = string
-    insecure   = optional(bool, false)
+    bucket_name = string
+    endpoint    = string
+    access_key  = string
+    secret_key  = string
+    insecure    = optional(bool, true)
   })
 ----
 
@@ -228,11 +228,11 @@ Description: The admin password for Grafana.
 [source]
 ----
 object({
-    bucket     = string
-    endpoint   = string
-    access_key = string
-    secret_key = string
-    insecure   = optional(bool, false)
+    bucket_name = string
+    endpoint    = string
+    access_key  = string
+    secret_key  = string
+    insecure    = optional(bool, true)
   })
 ----
 

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -260,7 +260,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/kind/extra-variables.tf
+++ b/kind/extra-variables.tf
@@ -1,11 +1,11 @@
 variable "metrics_storage" {
   description = "MinIO S3 bucket configuration values for the bucket where the archived metrics will be stored."
   type = object({
-    bucket     = string
-    endpoint   = string
-    access_key = string
-    secret_key = string
-    insecure   = optional(bool, false)
+    bucket_name = string
+    endpoint    = string
+    access_key  = string
+    secret_key  = string
+    insecure    = optional(bool, true)
   })
   default = null
 }

--- a/kind/locals.tf
+++ b/kind/locals.tf
@@ -1,3 +1,16 @@
 locals {
+  metrics_storage = var.metrics_storage != null ? {
+    storage_config = {
+      type = "s3"
+      config = {
+        bucket     = var.metrics_storage.bucket_name
+        endpoint   = var.metrics_storage.endpoint
+        access_key = var.metrics_storage.access_key
+        secret_key = var.metrics_storage.secret_key
+        insecure   = var.metrics_storage.insecure
+      }
+    }
+  } : null
+
   helm_values = []
 }

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -15,7 +15,7 @@ module "kube-prometheus-stack" {
   alertmanager = var.alertmanager
   grafana      = var.grafana
 
-  metrics_storage_main = var.metrics_storage != null ? { storage_config = merge({ type = "s3" }, { config = var.metrics_storage }) } : null
+  metrics_storage_main = local.metrics_storage
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -216,7 +216,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -396,7 +396,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -216,7 +216,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -300,7 +300,17 @@ Default: `{}`
 
 ==== [[input_alertmanager]] <<input_alertmanager,alertmanager>>
 
-Description: Alertmanager settings
+Description: Object containing Alertmanager settings. The following attributes are supported:
+
+* enabled: whether Alertmanager is deployed or not (default: `true`).
+* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
+* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * name: name of the configured route.
+  * channel: channel where the alerts will be sent (with '#').
+  * api_url: slack URL you received when configuring a webhook integration.
+  * matchers: list of strings for filtering which alerts will be sent.
 
 Type: `any`
 
@@ -396,7 +406,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -468,7 +478,18 @@ object({
 |no
 
 |[[input_alertmanager]] <<input_alertmanager,alertmanager>>
-|Alertmanager settings
+|Object containing Alertmanager settings. The following attributes are supported:
+
+* enabled: whether Alertmanager is deployed or not (default: `true`).
+* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
+* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * name: name of the configured route.
+  * channel: channel where the alerts will be sent (with '#').
+  * api_url: slack URL you received when configuring a webhook integration.
+  * matchers: list of strings for filtering which alerts will be sent.
+
 |`any`
 |`{}`
 |no

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -1,23 +1,144 @@
-= devops-stack-module-kube-prometheus-stack
-// Document attributes to replace along the document
-:chart-version: 45.22.0
-:chart-url: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack
+= SKS Variant
 
-A https://devops-stack.io[DevOps Stack] module to deploy and configure https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack[kube-prometheus-chart].
+This folder contains the variant to use when deploying in Exoscale using an SKS cluster.
 
-The kube-prometheus-stack chart used by this module is shipped in this repository as well, in order to avoid any unwanted behaviors caused by unsupported versions. 
+== Usage
 
-[cols="1,1,1",options="autowidth,header"]
-|===
-|Current Chart Version |Original Repository |Default Values
-|*{chart-version}* |{chart-url}[Chart] |https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/{chart-version}?modal=values[`values.yaml`]
-|===
+This module can be declared by adding the following block on your Terraform configuration:
 
-*Since this module is meant to be instantiated using its variants, the usage documentation is available in each variant* ( xref:./aks/README.adoc[AKS] | xref:./eks/README.adoc[EKS] | xref:./kind/README.adoc[KinD] | xref:./sks/README.adoc[SKS] ).
+[source,terraform]
+----
+module "kube-prometheus-stack" {
+  source = "git::https://github.com/camptocamp/devops-stack-module-kube-prometheus-stack//sks?ref=<RELEASE>"
 
-Below you will only find the technical reference automatically generated from the `*.tf` files on the root module. 
+  cluster_name     = module.sks.cluster_name
+  base_domain      = module.sks.base_domain
+  cluster_issuer   = local.cluster_issuer
+  argocd_namespace = module.argocd_bootstrap.argocd_namespace
 
-== Technical Documentation
+  prometheus = {
+    oidc = module.oidc.oidc
+  }
+  alertmanager = {
+    oidc = module.oidc.oidc
+  }
+  grafana = {
+    oidc = module.oidc.oidc
+  }
+
+  dependency_ids = {
+    argocd       = module.argocd_bootstrap.id
+    traefik      = module.traefik.id
+    cert-manager = module.cert-manager.id
+    keycloak     = module.keycloak.id
+    oidc         = module.oidc.id
+    longhorn     = module.longhorn.id
+    loki-stack   = module.loki-stack.id
+  }
+}
+----
+
+When also deploying Thanos in the same cluster, you need to configure the `metrics_storage` variable with the values of the bucket created for the Thanos module. *This will automatically activate the Thanos sidecar in the Prometheus pods as well as defining Thanos as the default data source for Grafana.*
+
+[source,terraform]
+----
+module "kube-prometheus-stack" {
+  source = "git::https://github.com/camptocamp/devops-stack-module-kube-prometheus-stack//sks?ref=<RELEASE>"
+
+  cluster_name     = module.sks.cluster_name
+  base_domain      = module.sks.base_domain
+  cluster_issuer   = local.cluster_issuer
+  argocd_namespace = module.argocd_bootstrap.argocd_namespace
+
+  metrics_storage = {
+    bucket_name = resource.aws_s3_bucket.this["thanos"].id
+    region      = resource.aws_s3_bucket.this["thanos"].region
+    access_key  = resource.exoscale_iam_access_key.s3_iam_key["thanos"].key
+    secret_key  = resource.exoscale_iam_access_key.s3_iam_key["thanos"].secret
+  }
+
+  prometheus = {
+    oidc = module.oidc.oidc
+  }
+  alertmanager = {
+    oidc = module.oidc.oidc
+  }
+  grafana = {
+    oidc = module.oidc.oidc
+  }
+
+  dependency_ids = {
+    argocd       = module.argocd_bootstrap.id
+    traefik      = module.traefik.id
+    cert-manager = module.cert-manager.id
+    keycloak     = module.keycloak.id
+    oidc         = module.oidc.id
+    longhorn     = module.longhorn.id
+    loki-stack   = module.loki-stack.id
+  }
+}
+----
+
+TIP: Check the xref:ROOT:ROOT:tutorials/deploy_sks.adoc[SKS deployment example] to see how to create the S3 bucket and to better understand the values passed on the example above.
+
+=== OIDC
+
+NOTE: This module was developed with OIDC in mind.
+
+There is an OIDC proxy container deployed as a sidecar on the pods of Prometheus and Alertmanager. As such, the `prometheus` and `alertmanager` variables are expected to have a map `oidc` containing at least the Issuer URL, the Client ID, and the Client Secret.
+
+As for Grafana, the OIDC configuration is done through the `grafana` variable. The `oidc` map is expected to contain the same values as for Prometheus and Alertmanager, but also the `oauth_url`, `token_url` and `api_url` values.
+
+You can pass these values by pointing an output from another module (as above), or by defining them explicitly:
+
+[source,terraform]
+----
+module "kube-prometheus-stack" {
+  ...
+  prometheus | alertmanager = {
+    oidc = {
+      issuer_url    = "<URL>"
+      client_id     = "<ID>"
+      client_secret = "<SECRET>"
+    }
+  }
+  grafana = {
+    oidc = {
+      issuer_url    = "<URL>"
+      client_id     = "<ID>"
+      client_secret = "<SECRET>"
+      oauth_url     = "<URL>"
+      token_url     = "<URL>"
+      api_url       = "<URL>"
+    }
+  }
+  ...
+}
+----
+
+== Technical Reference
+
+=== Dependencies
+
+==== `module.argocd_bootstrap.id`
+
+Obviously, the module depends on an already running Argo CD in the cluster in order for the application to be created.
+
+==== `module.traefik.id` and `module.cert-manager.id`
+
+This module has multiple ingresses and consequently it must be deployed after the module `traefik` and `cert-manager`.
+
+==== `module.keycloak.id` and `module.oidc.id`
+
+When using Keycloak as an OIDC provider for the Longhorn Dashboard, you need to add Keycloak and the OIDC module as dependencies.
+
+==== `module.longhorn.id`
+
+This module requires a Persistent Volume so it needs to be deployed after the module Longhorn.
+
+==== `module.loki-stack.id`
+
+In order to be able to check the logs collected by Loki in the Grafana interface, this module requires to be deployed after the module Loki, so it can detect it as a data source.
 
 // BEGIN_TF_DOCS
 === Requirements
@@ -34,37 +155,15 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
-=== Providers
+=== Modules
 
-The following providers are used by this module:
+The following Modules are called:
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+==== [[module_kube-prometheus-stack]] <<module_kube-prometheus-stack,kube-prometheus-stack>>
 
-- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+Source: ../
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
-
-- [[provider_helm]] <<provider_helm,helm>>
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
-=== Resources
-
-The following resources are used by this module:
-
-- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] (resource)
-- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] (resource)
-- https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace[kubernetes_namespace.kube_prometheus_stack_namespace] (resource)
-- https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret[kubernetes_secret.thanos_object_storage_secret] (resource)
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] (resource)
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.k8s_resources] (resource)
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
-- https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.grafana_admin_password] (resource)
-- https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.oauth2_cookie_secret] (resource)
-- https://registry.terraform.io/providers/hashicorp/helm/latest/docs/data-sources/template[helm_template.this] (data source)
-- https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] (data source)
+Version:
 
 === Required Inputs
 
@@ -86,6 +185,23 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
+
+Description: Exoscale SOS bucket configuration values for the bucket where the archived metrics will be stored.
+
+Type:
+[source,hcl]
+----
+object({
+    bucket_name = string
+    region      = string
+    access_key  = string
+    secret_key  = string
+  })
+----
+
+Default: `null`
+
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
 Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
@@ -100,7 +216,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -184,17 +300,7 @@ Default: `{}`
 
 ==== [[input_alertmanager]] <<input_alertmanager,alertmanager>>
 
-Description: Object containing Alertmanager settings. The following attributes are supported:
-
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+Description: Alertmanager settings
 
 Type: `any`
 
@@ -239,35 +345,12 @@ Description: The admin password for Grafana.
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
-= Providers
+= Modules
 
-[cols="a,a",options="header,autowidth"]
+[cols="a,a,a",options="header,autowidth"]
 |===
-|Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
-|[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_helm]] <<provider_helm,helm>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|===
-
-= Resources
-
-[cols="a,a",options="header,autowidth"]
-|===
-|Name |Type
-|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] |resource
-|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] |resource
-|https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace[kubernetes_namespace.kube_prometheus_stack_namespace] |resource
-|https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret[kubernetes_secret.thanos_object_storage_secret] |resource
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] |resource
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.k8s_resources] |resource
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] |resource
-|https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.grafana_admin_password] |resource
-|https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.oauth2_cookie_secret] |resource
-|https://registry.terraform.io/providers/hashicorp/helm/latest/docs/data-sources/template[helm_template.this] |data source
-|https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] |data source
+|Name |Source |Version
+|[[module_kube-prometheus-stack]] <<module_kube-prometheus-stack,kube-prometheus-stack>> |../ |
 |===
 
 = Inputs
@@ -275,6 +358,23 @@ Description: The admin password for Grafana.
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
+|[[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
+|Exoscale SOS bucket configuration values for the bucket where the archived metrics will be stored.
+|
+
+[source]
+----
+object({
+    bucket_name = string
+    region      = string
+    access_key  = string
+    secret_key  = string
+  })
+----
+
+|`null`
+|no
+
 |[[input_cluster_name]] <<input_cluster_name,cluster_name>>
 |Name given to the cluster. Value used for naming some the resources created by the module.
 |`string`
@@ -296,7 +396,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -368,18 +468,7 @@ object({
 |no
 
 |[[input_alertmanager]] <<input_alertmanager,alertmanager>>
-|Object containing Alertmanager settings. The following attributes are supported:
-
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
-
+|Alertmanager settings
 |`any`
 |`{}`
 |no

--- a/sks/extra-variables.tf
+++ b/sks/extra-variables.tf
@@ -1,0 +1,10 @@
+variable "metrics_storage" {
+  description = "Exoscale SOS bucket configuration values for the bucket where the archived metrics will be stored."
+  type = object({
+    bucket_name = string
+    region      = string
+    access_key  = string
+    secret_key  = string
+  })
+  default = null
+}

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -1,0 +1,15 @@
+locals {
+  metrics_storage = var.metrics_storage != null ? {
+    storage_config = {
+      type = "s3"
+      config = {
+        bucket     = var.metrics_storage.bucket_name
+        endpoint   = "sos-${var.metrics_storage.region}.exo.io"
+        access_key = var.metrics_storage.access_key
+        secret_key = var.metrics_storage.secret_key
+      }
+    }
+  } : null
+
+  helm_values = []
+}

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,0 +1,21 @@
+module "kube-prometheus-stack" {
+  source = "../"
+
+  cluster_name           = var.cluster_name
+  base_domain            = var.base_domain
+  argocd_namespace       = var.argocd_namespace
+  target_revision        = var.target_revision
+  cluster_issuer         = var.cluster_issuer
+  namespace              = var.namespace
+  deep_merge_append_list = var.deep_merge_append_list
+  app_autosync           = var.app_autosync
+  dependency_ids         = var.dependency_ids
+
+  prometheus   = var.prometheus
+  alertmanager = var.alertmanager
+  grafana      = var.grafana
+
+  metrics_storage_main = local.metrics_storage
+
+  helm_values = concat(local.helm_values, var.helm_values)
+}

--- a/sks/outputs.tf
+++ b/sks/outputs.tf
@@ -1,0 +1,10 @@
+output "id" {
+  description = "ID to pass other modules in order to refer to this module as a dependency."
+  value       = module.kube-prometheus-stack.id
+}
+
+output "grafana_admin_password" {
+  description = "The admin password for Grafana."
+  value       = module.kube-prometheus-stack.grafana_admin_password
+  sensitive   = true
+}

--- a/sks/terraform.tf
+++ b/sks/terraform.tf
@@ -1,0 +1,1 @@
+../terraform.tf

--- a/sks/variables.tf
+++ b/sks/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf


### PR DESCRIPTION
## Description of the changes

- Add support for SKS clusters and SOS bucket storage.
- Refactor the code through all variants to improve the readability and rename a few parameters in the variables (_see next section_). 

:warning: **Do a _Rebase and merge_.**

## Breaking change

- [x] Yes (in the module itself): I've renamed some parameters in the `metrics_storage` variable to standardize the way the variable is defined. In my view, since the variable normally contains the same parameters for the Thanos and kube-prometheus-module, as it is the same bucket, **by doing these changes, we could then define a local on the calling module to be passed to both called modules.**

## Tests executed on which distribution(s)

- [x] KinD
- [ ] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)