### PR TITLE
feat!: add support to oboukili/argocd v5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "argocd_project" "this" {
       namespace = var.namespace
     }
 
-    # This extra destination block is needed by the v1/Service 
+    # This extra destination block is needed by the v1/Service
     # kube-prometheus-stack-coredns and kube-prometheus-stack-kubelet
     # that have to be inside kube-system.
     destination {
@@ -119,18 +119,23 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = var.app_autosync
+      automated {
+        prune       = var.app_autosync.prune
+        self_heal   = var.app_autosync.self_heal
+        allow_empty = var.app_autosync.allow_empty
+      }
 
       retry {
-        backoff = {
+        backoff {
           duration     = "20s"
-          max_duration = "5m"
+          max_duration = "2m"
+          factor       = "2"
         }
-        limit = "3"
+        limit = "5"
       }
 
       sync_options = [
-        "CreateNamespace=false"
+        "CreateNamespace=true"
       ]
     }
   }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     argocd = {
       source  = "oboukili/argocd"
-      version = ">= 4"
+      version = ">= 5"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

Adapt the module to be compatible with ArgoCD versions >= 5.x (in counterpart, it now incompatible with previous versions of the provider). 
This change to the provider is needed to work with ArgoCD 2.7.x

## Breaking change

- [ ] No
- [ ] Yes (in the Helm chart(s))
- [x] Yes (in the module itself): _the module is no longer compatible with argocd provider versions < 5.x_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [x] SKS (Exoscale)