### PR TITLE
fix: add variable to deactivate the output of Helm templates on plan

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ The kube-prometheus-stack chart used by this module is shipped in this repositor
 [cols="1,1,1",options="autowidth,header"]
 |===
 |Current Chart Version |Original Repository |Default Values
-|*{chart-version}* |{chart-url}[Chart] |https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/{chart-version}?modal=values[`values.yaml`]
+|*{kube-prometheus-stack-chart-version}* |{chart-url}[Chart] |https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/{chart-version}?modal=values[`values.yaml`]
 |===
 
 *Since this module is meant to be instantiated using its variants, the usage documentation is available in each variant* ( xref:./aks/README.adoc[AKS] | xref:./eks/README.adoc[EKS] | xref:./kind/README.adoc[KinD] | xref:./sks/README.adoc[SKS] ).

--- a/README.adoc
+++ b/README.adoc
@@ -100,7 +100,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -129,6 +129,15 @@ Default: `[]`
 ==== [[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 
 Description: A boolean flag to enable/disable appending lists instead of overwriting them.
+
+Type: `bool`
+
+Default: `false`
+
+==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+
+Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -244,11 +253,11 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_helm]] <<provider_helm,helm>> |n/a
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
@@ -296,7 +305,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -319,6 +328,14 @@ Description: The admin password for Grafana.
 
 |[[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 |A boolean flag to enable/disable appending lists instead of overwriting them.
+|`bool`
+|`false`
+|no
+
+|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|A boolean to enable/disable outputting Helm templates on the Terraform plan.
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+
 |`bool`
 |`false`
 |no

--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
@@ -48,7 +48,7 @@ The following providers are used by this module:
 
 - [[provider_helm]] <<provider_helm,helm>>
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -137,7 +137,7 @@ Default: `false`
 ==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -195,15 +195,15 @@ Default: `{}`
 
 Description: Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 Type: `any`
 
@@ -254,10 +254,10 @@ Description: The admin password for Grafana.
 |===
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_helm]] <<provider_helm,helm>> |n/a
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
@@ -334,7 +334,7 @@ Description: The admin password for Grafana.
 
 |[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 |`bool`
 |`false`
@@ -387,15 +387,15 @@ object({
 |[[input_alertmanager]] <<input_alertmanager,alertmanager>>
 |Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 |`any`
 |`{}`

--- a/README.adoc
+++ b/README.adoc
@@ -38,17 +38,17 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
-
-- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_helm]] <<provider_helm,helm>>
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Resources
 
@@ -134,10 +134,10 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+==== [[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 Type: `bool`
 
@@ -253,11 +253,11 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_helm]] <<provider_helm,helm>> |n/a
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
@@ -332,9 +332,9 @@ Description: The admin password for Grafana.
 |`false`
 |no
 
-|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|[[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 |`bool`
 |`false`

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -126,7 +126,7 @@ Default: `false`
 ==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -184,15 +184,15 @@ Default: `{}`
 
 Description: Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 Type: `any`
 
@@ -330,7 +330,7 @@ object({
 
 |[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 |`bool`
 |`false`
@@ -383,15 +383,15 @@ object({
 |[[input_alertmanager]] <<input_alertmanager,alertmanager>>
 |Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 |`any`
 |`{}`

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -89,7 +89,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -118,6 +118,15 @@ Default: `[]`
 ==== [[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 
 Description: A boolean flag to enable/disable appending lists instead of overwriting them.
+
+Type: `bool`
+
+Default: `false`
+
+==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+
+Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -292,7 +301,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -315,6 +324,14 @@ object({
 
 |[[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 |A boolean flag to enable/disable appending lists instead of overwriting them.
+|`bool`
+|`false`
+|no
+
+|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|A boolean to enable/disable outputting Helm templates on the Terraform plan.
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+
 |`bool`
 |`false`
 |no

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -123,10 +123,10 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+==== [[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 Type: `bool`
 
@@ -328,9 +328,9 @@ object({
 |`false`
 |no
 
-|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|[[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 |`bool`
 |`false`

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -4,4 +4,5 @@
 ** xref:ROOT:eks/README.adoc[EKS]
 ** xref:ROOT:kind/README.adoc[KinD]
 ** xref:ROOT:sks/README.adoc[SKS]
+* https://github.com/camptocamp/devops-stack-module-kube-prometheus-stack[Repository,window=_blank]
 * xref:ROOT:ROOT:index.adoc[_Return to DevOps Stack docs_]

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -110,7 +110,7 @@ Default: `false`
 ==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -168,15 +168,15 @@ Default: `{}`
 
 Description: Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 Type: `any`
 
@@ -294,7 +294,7 @@ object({
 
 |[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 |`bool`
 |`false`
@@ -347,15 +347,15 @@ object({
 |[[input_alertmanager]] <<input_alertmanager,alertmanager>>
 |Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 |`any`
 |`{}`

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -107,10 +107,10 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+==== [[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 Type: `bool`
 
@@ -292,9 +292,9 @@ object({
 |`false`
 |no
 
-|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|[[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 |`bool`
 |`false`

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -73,7 +73,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -102,6 +102,15 @@ Default: `[]`
 ==== [[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 
 Description: A boolean flag to enable/disable appending lists instead of overwriting them.
+
+Type: `bool`
+
+Default: `false`
+
+==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+
+Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -256,7 +265,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -279,6 +288,14 @@ object({
 
 |[[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 |A boolean flag to enable/disable appending lists instead of overwriting them.
+|`bool`
+|`false`
+|no
+
+|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|A boolean to enable/disable outputting Helm templates on the Terraform plan.
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+
 |`bool`
 |`false`
 |no

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -112,7 +112,7 @@ Default: `false`
 ==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -170,15 +170,15 @@ Default: `{}`
 
 Description: Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 Type: `any`
 
@@ -298,7 +298,7 @@ object({
 
 |[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 |`bool`
 |`false`
@@ -351,15 +351,15 @@ object({
 |[[input_alertmanager]] <<input_alertmanager,alertmanager>>
 |Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 |`any`
 |`{}`

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -109,10 +109,10 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+==== [[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 Type: `bool`
 
@@ -296,9 +296,9 @@ object({
 |`false`
 |no
 
-|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|[[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 |`bool`
 |`false`

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -75,7 +75,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -104,6 +104,15 @@ Default: `[]`
 ==== [[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 
 Description: A boolean flag to enable/disable appending lists instead of overwriting them.
+
+Type: `bool`
+
+Default: `false`
+
+==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+
+Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -260,7 +269,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -283,6 +292,14 @@ object({
 
 |[[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 |A boolean flag to enable/disable appending lists instead of overwriting them.
+|`bool`
+|`false`
+|no
+
+|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|A boolean to enable/disable outputting Helm templates on the Terraform plan.
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+
 |`bool`
 |`false`
 |no

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ data "utils_deep_merge_yaml" "values" {
 }
 
 data "helm_template" "this" {
-  count = var.verbose_helm_templates ? 1 : 0
+  count = var.show_manifest_diff ? 1 : 0
 
   name      = "kube-prometheus-stack"
   namespace = var.namespace
@@ -83,7 +83,7 @@ data "helm_template" "this" {
 }
 
 resource "null_resource" "k8s_resources" {
-  count = var.verbose_helm_templates ? 1 : 0
+  count = var.show_manifest_diff ? 1 : 0
 
   triggers = data.helm_template.this[0].manifests
 }

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,8 @@ data "utils_deep_merge_yaml" "values" {
 }
 
 data "helm_template" "this" {
+  count = var.verbose_helm_templates ? 1 : 0
+
   name      = "kube-prometheus-stack"
   namespace = var.namespace
   chart     = "${path.module}/charts/kube-prometheus-stack"
@@ -81,7 +83,9 @@ data "helm_template" "this" {
 }
 
 resource "null_resource" "k8s_resources" {
-  triggers = data.helm_template.this.manifests
+  count = var.verbose_helm_templates ? 1 : 0
+
+  triggers = data.helm_template.this[0].manifests
 }
 
 resource "argocd_application" "this" {

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -250,10 +250,10 @@ Type: `bool`
 
 Default: `false`
 
-==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+==== [[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 Type: `bool`
 
@@ -442,9 +442,9 @@ object({
 |`false`
 |no
 
-|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|[[input_show_manifest_diff]] <<input_show_manifest_diff,show_manifest_diff>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
 
 |`bool`
 |`false`

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -216,7 +216,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v6.0.0"`
+Default: `"v6.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -245,6 +245,15 @@ Default: `[]`
 ==== [[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 
 Description: A boolean flag to enable/disable appending lists instead of overwriting them.
+
+Type: `bool`
+
+Default: `false`
+
+==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+
+Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -406,7 +415,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v6.0.0"`
+|`"v6.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -429,6 +438,14 @@ object({
 
 |[[input_deep_merge_append_list]] <<input_deep_merge_append_list,deep_merge_append_list>>
 |A boolean flag to enable/disable appending lists instead of overwriting them.
+|`bool`
+|`false`
+|no
+
+|[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
+|A boolean to enable/disable outputting Helm templates on the Terraform plan.
+This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+
 |`bool`
 |`false`
 |no

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -253,7 +253,7 @@ Default: `false`
 ==== [[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 
 Description: A boolean to enable/disable outputting Helm templates on the Terraform plan.  
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 Type: `bool`
 
@@ -311,15 +311,15 @@ Default: `{}`
 
 Description: Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 Type: `any`
 
@@ -444,7 +444,7 @@ object({
 
 |[[input_verbose_helm_templates]] <<input_verbose_helm_templates,verbose_helm_templates>>
 |A boolean to enable/disable outputting Helm templates on the Terraform plan.
-This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
 
 |`bool`
 |`false`
@@ -497,15 +497,15 @@ object({
 |[[input_alertmanager]] <<input_alertmanager,alertmanager>>
 |Object containing Alertmanager settings. The following attributes are supported:
 
-* enabled: whether Alertmanager is deployed or not (default: `true`).
-* domain: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
-* oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-* deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-* slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-  * name: name of the configured route.
-  * channel: channel where the alerts will be sent (with '#').
-  * api_url: slack URL you received when configuring a webhook integration.
-  * matchers: list of strings for filtering which alerts will be sent.
+* `enabled`: whether Alertmanager is deployed or not (default: `true`).
+* `domain`: domain name configured in the Ingress (default: `prometheus.apps.${var.cluster_name}.${var.base_domain}`).
+* `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+* `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+* `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+  * `name`: name of the configured route.
+  * `channel`: channel where the alerts will be sent (with '#').
+  * `api_url`: slack URL you received when configuring a webhook integration.
+  * `matchers`: list of strings for filtering which alerts will be sent.
 
 |`any`
 |`{}`

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "deep_merge_append_list" {
 variable "verbose_helm_templates" {
   description = <<-EOT
     A boolean to enable/disable outputting Helm templates on the Terraform plan.
-    This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+    This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
   EOT
   type        = bool
   default     = false
@@ -96,15 +96,15 @@ variable "alertmanager" {
   description = <<-EOT
     Object containing Alertmanager settings. The following attributes are supported:
 
-    * enabled: whether Alertmanager is deployed or not (default: `true`).
-    * domain: domain name configured in the Ingress (default: `prometheus.apps.$${var.cluster_name}.$${var.base_domain}`).
-    * oidc: OIDC configuration to be used by oauth2_proxy in front of Alertmanager (Mandatory).
-    * deadmanssnitch_url: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
-    * slack_routes: list of objects configuring routing of alerts to Slack channels, with the following attributes:
-      * name: name of the configured route.
-      * channel: channel where the alerts will be sent (with '#').
-      * api_url: slack URL you received when configuring a webhook integration.
-      * matchers: list of strings for filtering which alerts will be sent.
+    * `enabled`: whether Alertmanager is deployed or not (default: `true`).
+    * `domain`: domain name configured in the Ingress (default: `prometheus.apps.$${var.cluster_name}.$${var.base_domain}`).
+    * `oidc`: OIDC configuration to be used by OAuth2 Proxy in front of Alertmanager (**required**).
+    * `deadmanssnitch_url`: url of a Dead Man's Snitch service Alertmanager should report to (by default this reporing is disabled).
+    * `slack_routes`: list of objects configuring routing of alerts to Slack channels, with the following attributes:
+      * `name`: name of the configured route.
+      * `channel`: channel where the alerts will be sent (with '#').
+      * `api_url`: slack URL you received when configuring a webhook integration.
+      * `matchers`: list of strings for filtering which alerts will be sent.
   EOT
   type        = any
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,15 @@ variable "deep_merge_append_list" {
   default     = false
 }
 
+variable "verbose_helm_templates" {
+  description = <<-EOT
+    A boolean to enable/disable outputting Helm templates on the Terraform plan.
+    This is useful for debugging purposes ONLY. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+  EOT
+  type        = bool
+  default     = false
+}
+
 variable "app_autosync" {
   description = "Automated sync options for the Argo CD Application resource."
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -48,10 +48,10 @@ variable "deep_merge_append_list" {
   default     = false
 }
 
-variable "verbose_helm_templates" {
+variable "show_manifest_diff" {
   description = <<-EOT
     A boolean to enable/disable outputting Helm templates on the Terraform plan.
-    This is useful for debugging purposes only. **Do not enable this flag in production as this will output secrets (namely the Kubernetes secrets in base64 format) in the Terraform state.**
+    This is useful for debugging purposes only. *Make sure no secrets appear in the Kubernetes manifests before setting this flag, otherwise they will be exposed in your Terraform plan.*
   EOT
   type        = bool
   default     = false


### PR DESCRIPTION
## Description of the changes

Adds a variable to conditionally enable the output of Helm templates on the Terraform plan. I've set the value as false, as discussed and added a warning to the variable description, as discussed in our weekly.

:warning: **Please note that the first time you apply this release, it will output a monstrous Terraform plan saying a resource will be deleted as long as thousands of lines.** To avoid problems, it's best you only apply this change without any other changes at the same time.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] SKS (Exoscale)