### PR TITLE
feat: add variables to set AppProject, labels and destination cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,9 +38,9 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
@@ -93,6 +93,30 @@ Description: Namespace used by Argo CD where the Application and AppProject reso
 Type: `string`
 
 Default: `"argocd"`
+
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -253,12 +277,12 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_helm]] <<provider_helm,helm>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -300,6 +324,24 @@ Description: The admin password for Grafana.
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -83,6 +83,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -296,6 +320,24 @@ object({
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -34,6 +34,7 @@ module "kube-prometheus-stack" {
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -33,6 +33,8 @@ module "kube-prometheus-stack" {
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
   namespace              = var.namespace

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -67,6 +67,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -260,6 +284,24 @@ object({
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -5,6 +5,7 @@ module "kube-prometheus-stack" {
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -4,6 +4,8 @@ module "kube-prometheus-stack" {
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
   namespace              = var.namespace

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -69,6 +69,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -264,6 +288,24 @@ object({
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -5,6 +5,7 @@ module "kube-prometheus-stack" {
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -4,6 +4,8 @@ module "kube-prometheus-stack" {
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
   namespace              = var.namespace

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  oauth2_proxy_image       = "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
-  curl_wait_for_oidc_image = "curlimages/curl:8.1.1"
+  oauth2_proxy_image       = "quay.io/oauth2-proxy/oauth2-proxy:v7.5.0"
+  curl_wait_for_oidc_image = "curlimages/curl:8.3.0"
 
   ingress_annotations = {
     "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,10 @@ resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "kube-prometheus-stack-${var.destination_cluster}" : "kube-prometheus-stack"
     namespace = var.argocd_namespace
+    labels = merge({
+      "application" = "kube-prometheus-stack"
+      "cluster"     = var.destination_cluster
+    }, var.argocd_labels)
   }
 
   timeouts {

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -210,6 +210,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -410,6 +434,24 @@ object({
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -5,6 +5,7 @@ module "kube-prometheus-stack" {
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -4,6 +4,8 @@ module "kube-prometheus-stack" {
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
   namespace              = var.namespace

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,18 @@ variable "argocd_namespace" {
   default     = "argocd"
 }
 
+variable "argocd_project" {
+  description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
+  type        = string
+  default     = null
+}
+
+variable "destination_cluster" {
+  description = "Destination cluster where the application should be deployed."
+  type        = string
+  default     = "in-cluster"
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "argocd_project" {
   default     = null
 }
 
+variable "argocd_labels" {
+  description = "Labels to attach to the Argo CD Application resource."
+  type        = map(string)
+  default     = {}
+}
+
 variable "destination_cluster" {
   description = "Destination cluster where the application should be deployed."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR:
- Adds the required variables and configuration to allow the module to be deployed on a different cluster than Argo CD.
- Adds the possibility of placing the application inside a specified Argo CD project in order to avoid having a single project for each application throughout multiple clusters.
- Adds labels and a variable to add more labels to the Argo CD application to make it easier to sort applications on the web interface of Argo CD.
- Updates the images of OAuth2-Proxy and curl. 

**All these changes are made in preparation for having a centralized Argo CD that controls applications throughout multiple clusters.**

:warning: **Do a _Rebase and merge_.**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] EKS (AWS)
- [x] SKS (Exoscale)