### PR TITLE
feat(kind): add a subdomain variable

### DIFF
--- a/aks/main.tf
+++ b/aks/main.tf
@@ -32,6 +32,7 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
@@ -51,4 +52,3 @@ module "kube-prometheus-stack" {
 
   helm_values = concat(local.helm_values, var.helm_values)
 }
-

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -3,6 +3,7 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -3,6 +3,7 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels

--- a/locals.tf
+++ b/locals.tf
@@ -15,7 +15,7 @@ locals {
     enabled                  = true
     additional_data_sources  = false
     generic_oauth_extra_args = {}
-    domain                   = "grafana.apps.${var.cluster_name}.${var.base_domain}"
+    domain                   = "grafana.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
     admin_password           = random_password.grafana_admin_password.result
   }
 
@@ -26,7 +26,7 @@ locals {
 
   prometheus_defaults = {
     enabled = true
-    domain  = "prometheus.apps.${var.cluster_name}.${var.base_domain}"
+    domain  = "prometheus.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
   }
 
   prometheus = merge(
@@ -36,7 +36,7 @@ locals {
 
   alertmanager_defaults = {
     enabled            = true
-    domain             = "alertmanager.apps.${var.cluster_name}.${var.base_domain}"
+    domain             = "alertmanager.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
     deadmanssnitch_url = null
     slack_routes       = []
   }
@@ -155,14 +155,14 @@ locals {
           servicePort = "9095"
           hosts = [
             "${local.alertmanager.domain}",
-            "alertmanager.apps.${var.base_domain}"
+            "alertmanager.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}"
           ]
           tls = [
             {
               secretName = "alertmanager-tls"
               hosts = [
                 "${local.alertmanager.domain}",
-                "alertmanager.apps.${var.base_domain}",
+                "alertmanager.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
               ]
             },
           ]
@@ -233,14 +233,14 @@ locals {
           annotations = local.ingress_annotations
           hosts = [
             "${local.grafana.domain}",
-            "grafana.apps.${var.base_domain}",
+            "grafana.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
           ]
           tls = [
             {
               secretName = "grafana-tls"
               hosts = [
                 "${local.grafana.domain}",
-                "grafana.apps.${var.base_domain}",
+                "grafana.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
               ]
             },
           ]
@@ -284,14 +284,14 @@ locals {
           servicePort = "9091"
           hosts = [
             "${local.prometheus.domain}",
-            "prometheus.apps.${var.base_domain}",
+            "prometheus.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
           ]
           tls = [
             {
               secretName = "prometheus-tls"
               hosts = [
                 "${local.prometheus.domain}",
-                "prometheus.apps.${var.base_domain}",
+                "prometheus.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
               ]
             },
           ]

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -3,6 +3,7 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "base_domain" {
   type        = string
 }
 
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
+}
+
 variable "argocd_namespace" {
   description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
   type        = string


### PR DESCRIPTION
## Description of the changes

Hello, 

We have a need to use URLs without the **.apps.** part, in order to achieve that without introducing a breaking change we propose a new variable **subdomain** that defaults to apps, that way we can set it to an empty string on our side.

We transmit it only to the kind variable since its were we needed but I can make the changes for the other variants.

Regards.

## Breaking change

- [X] No

## Tests executed on which distribution(s)

- [X] KinD variant on a K3S cluster
