### PR TITLE
fix(Grafana): Thanos datasource url

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,13 +40,13 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
-
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -264,10 +264,10 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 

--- a/locals.tf
+++ b/locals.tf
@@ -213,7 +213,7 @@ locals {
         }
         additionalDataSources = [merge(var.metrics_storage_main != null ? {
           name = "Thanos"
-          url  = "http://thanos-query.thanos:9090"
+          url  = "http://thanos-query-frontend.thanos:9090"
           } : {
           name = "Prometheus"
           url  = "http://kube-prometheus-stack-prometheus:9090"


### PR DESCRIPTION
## Description of the changes

Use thanos frontend to ensure Query splitting and other config is applied.

:warning: Grafana pod might need a restart to apply the new config.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)