### PR TITLE
fix(Grafana): increase timeout for long queries

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -205,6 +205,9 @@ locals {
             domain   = "${local.grafana.domain}"
             root_url = "https://%(domain)s" # TODO check this
           }
+          dataproxy = {
+            timeout = 900
+          }
         }
         sidecar = {
           datasources = {


### PR DESCRIPTION
## Description of the changes

Solves -> https://community.grafana.com/t/timeout-awaiting-response-header-error-while-querying/57592
A recurrent error when querying for long periods. Default is 30 seconds.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)