### PR TITLE
feat(alertmanager): continue matching

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,11 +42,11 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Resources
 
@@ -120,7 +120,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.0.2"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -215,6 +215,7 @@ Description: Object containing Alertmanager settings. The following attributes a
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 Type: `any`
 
@@ -264,10 +265,10 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
@@ -331,7 +332,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.0.2"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -414,6 +415,7 @@ object({
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 |`any`
 |`{}`

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -113,7 +113,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.0.2"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -208,6 +208,7 @@ Description: Object containing Alertmanager settings. The following attributes a
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 Type: `any`
 
@@ -334,7 +335,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.0.2"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -417,6 +418,7 @@ object({
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 |`any`
 |`{}`

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -97,7 +97,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.0.2"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -192,6 +192,7 @@ Description: Object containing Alertmanager settings. The following attributes a
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 Type: `any`
 
@@ -298,7 +299,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.0.2"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -381,6 +382,7 @@ object({
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 |`any`
 |`{}`

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -99,7 +99,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.0.2"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -194,6 +194,7 @@ Description: Object containing Alertmanager settings. The following attributes a
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 Type: `any`
 
@@ -302,7 +303,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.0.2"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -385,6 +386,7 @@ object({
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 |`any`
 |`{}`

--- a/locals.tf
+++ b/locals.tf
@@ -78,6 +78,7 @@ locals {
       [for item in local.alertmanager.slack_routes : {
         matchers = item["matchers"]
         receiver = item["name"]
+        continue = lookup(item, "continue", false)
       }]
     ])
   }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -240,7 +240,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.0"`
+Default: `"v8.0.2"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -335,6 +335,7 @@ Description: Object containing Alertmanager settings. The following attributes a
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 Type: `any`
 
@@ -448,7 +449,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.0"`
+|`"v8.0.2"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -531,6 +532,7 @@ object({
   * `channel`: channel where the alerts will be sent (with '#').
   * `api_url`: slack URL you received when configuring a webhook integration.
   * `matchers`: list of strings for filtering which alerts will be sent.
+  * `continue`: whether an alert should continue matching subsequent sibling nodes.
 
 |`any`
 |`{}`

--- a/variables.tf
+++ b/variables.tf
@@ -114,6 +114,7 @@ variable "alertmanager" {
       * `channel`: channel where the alerts will be sent (with '#').
       * `api_url`: slack URL you received when configuring a webhook integration.
       * `matchers`: list of strings for filtering which alerts will be sent.
+      * `continue`: whether an alert should continue matching subsequent sibling nodes.
   EOT
   type        = any
   default     = {}


### PR DESCRIPTION
Enables routes to be matched several times (opt-in). This doesn't change default behavior.

Note: the default value that was added in the `locals.tf`, the `continue: false`, will be shown in your next terraform plan.



## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)