### PR TITLE
feat(grafana): create a variable to set a dataproxy time

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,15 +38,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -120,7 +120,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.2"`
+Default: `"v8.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -229,6 +229,14 @@ Type: `any`
 
 Default: `{}`
 
+==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+
+Description: This variable is used to setup dataproxy timeout.
+
+Type: `number`
+
+Default: `30`
+
 === Outputs
 
 The following outputs are exported:
@@ -332,7 +340,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.2"`
+|`"v8.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -425,6 +433,12 @@ object({
 |Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
 |`any`
 |`{}`
+|no
+
+|[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+|This variable is used to setup dataproxy timeout.
+|`number`
+|`30`
 |no
 
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -38,9 +38,9 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
+
+- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
@@ -231,7 +231,7 @@ Default: `{}`
 
 ==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
 
-Description: This variable is used to setup dataproxy timeout.
+Description: Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 
 Type: `number`
 
@@ -436,7 +436,7 @@ object({
 |no
 
 |[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
-|This variable is used to setup dataproxy timeout.
+|Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
 |no

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -113,7 +113,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.2"`
+Default: `"v8.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -221,6 +221,14 @@ Description: Storage settings for the Thanos sidecar. Needs to be of type `any` 
 Type: `any`
 
 Default: `{}`
+
+==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+
+Description: This variable is used to setup dataproxy timeout.
+
+Type: `number`
+
+Default: `30`
 
 === Outputs
 
@@ -335,7 +343,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.2"`
+|`"v8.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -428,6 +436,12 @@ object({
 |Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
 |`any`
 |`{}`
+|no
+
+|[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+|This variable is used to setup dataproxy timeout.
+|`number`
+|`30`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -224,7 +224,7 @@ Default: `{}`
 
 ==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
 
-Description: This variable is used to setup dataproxy timeout.
+Description: Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 
 Type: `number`
 
@@ -439,7 +439,7 @@ object({
 |no
 
 |[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
-|This variable is used to setup dataproxy timeout.
+|Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
 |no

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -97,7 +97,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.2"`
+Default: `"v8.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -206,6 +206,14 @@ Type: `any`
 
 Default: `{}`
 
+==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+
+Description: This variable is used to setup dataproxy timeout.
+
+Type: `number`
+
+Default: `30`
+
 === Outputs
 
 The following outputs are exported:
@@ -299,7 +307,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.2"`
+|`"v8.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -392,6 +400,12 @@ object({
 |Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
 |`any`
 |`{}`
+|no
+
+|[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+|This variable is used to setup dataproxy timeout.
+|`number`
+|`30`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -208,7 +208,7 @@ Default: `{}`
 
 ==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
 
-Description: This variable is used to setup dataproxy timeout.
+Description: Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 
 Type: `number`
 
@@ -403,7 +403,7 @@ object({
 |no
 
 |[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
-|This variable is used to setup dataproxy timeout.
+|Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
 |no

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -210,7 +210,7 @@ Default: `{}`
 
 ==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
 
-Description: This variable is used to setup dataproxy timeout.
+Description: Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 
 Type: `number`
 
@@ -407,7 +407,7 @@ object({
 |no
 
 |[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
-|This variable is used to setup dataproxy timeout.
+|Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
 |no

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -99,7 +99,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.2"`
+Default: `"v8.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -208,6 +208,14 @@ Type: `any`
 
 Default: `{}`
 
+==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+
+Description: This variable is used to setup dataproxy timeout.
+
+Type: `number`
+
+Default: `30`
+
 === Outputs
 
 The following outputs are exported:
@@ -303,7 +311,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.2"`
+|`"v8.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -396,6 +404,12 @@ object({
 |Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
 |`any`
 |`{}`
+|no
+
+|[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+|This variable is used to setup dataproxy timeout.
+|`number`
+|`30`
 |no
 
 |===

--- a/locals.tf
+++ b/locals.tf
@@ -207,7 +207,7 @@ locals {
             root_url = "https://%(domain)s" # TODO check this
           }
           dataproxy = {
-            timeout = 900
+            timeout = var.dataproxy_timeout
           }
         }
         sidecar = {

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -351,7 +351,7 @@ Default: `{}`
 
 ==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
 
-Description: This variable is used to setup dataproxy timeout.
+Description: Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 
 Type: `number`
 
@@ -553,7 +553,7 @@ object({
 |no
 
 |[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
-|This variable is used to setup dataproxy timeout.
+|Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
 |no

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -240,7 +240,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.0.2"`
+Default: `"v8.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -349,6 +349,14 @@ Type: `any`
 
 Default: `{}`
 
+==== [[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+
+Description: This variable is used to setup dataproxy timeout.
+
+Type: `number`
+
+Default: `30`
+
 === Outputs
 
 The following outputs are exported:
@@ -449,7 +457,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.0.2"`
+|`"v8.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -542,6 +550,12 @@ object({
 |Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
 |`any`
 |`{}`
+|no
+
+|[[input_dataproxy_timeout]] <<input_dataproxy_timeout,dataproxy_timeout>>
+|This variable is used to setup dataproxy timeout.
+|`number`
+|`30`
 |no
 
 |===

--- a/variables.tf
+++ b/variables.tf
@@ -125,3 +125,9 @@ variable "metrics_storage_main" {
   type        = any
   default     = {}
 }
+
+variable "dataproxy_timeout" {
+  description = "This variable is used to setup dataproxy timeout."
+  type        = number
+  default     = 30
+}

--- a/variables.tf
+++ b/variables.tf
@@ -127,7 +127,7 @@ variable "metrics_storage_main" {
 }
 
 variable "dataproxy_timeout" {
-  description = "This variable is used to setup dataproxy timeout."
+  description = "Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired."
   type        = number
   default     = 30
 }


### PR DESCRIPTION
## Description of the changes

This PR adds a variable to customize the dataproxy timeout, which is set to 30 seconds by default. This allows to increase the timeout if needed for example timeout awaiting response header error while querying.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)