### PR TITLE
fix!: change the default cluster issuer, remove the namespace variable and hardcode the Helm release name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,15 +38,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
-- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
-
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -82,14 +82,6 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -120,7 +112,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.1.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -128,15 +120,7 @@ Description: SSL certificate issuer to use. Usually you would configure this val
 
 Type: `string`
 
-Default: `"ca-issuer"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"kube-prometheus-stack"`
+Default: `"selfsigned-issuer"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -313,12 +297,6 @@ Description: The admin password for Grafana.
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -340,19 +318,13 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.1.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 |`string`
-|`"ca-issuer"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"kube-prometheus-stack"`
+|`"selfsigned-issuer"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -75,14 +75,6 @@ object({
 
 Default: `null`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -113,7 +105,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.1.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -121,15 +113,7 @@ Description: SSL certificate issuer to use. Usually you would configure this val
 
 Type: `string`
 
-Default: `"ca-issuer"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"kube-prometheus-stack"`
+Default: `"selfsigned-issuer"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -316,12 +300,6 @@ object({
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -343,19 +321,13 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.1.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 |`string`
-|`"ca-issuer"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"kube-prometheus-stack"`
+|`"selfsigned-issuer"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -32,7 +32,6 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -38,7 +38,6 @@ module "kube-prometheus-stack" {
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
-  namespace              = var.namespace
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -59,14 +59,6 @@ object({
 
 Default: `null`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -97,7 +89,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.1.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -105,15 +97,7 @@ Description: SSL certificate issuer to use. Usually you would configure this val
 
 Type: `string`
 
-Default: `"ca-issuer"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"kube-prometheus-stack"`
+Default: `"selfsigned-issuer"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -280,12 +264,6 @@ object({
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -307,19 +285,13 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.1.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 |`string`
-|`"ca-issuer"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"kube-prometheus-stack"`
+|`"selfsigned-issuer"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -9,7 +9,6 @@ module "kube-prometheus-stack" {
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
-  namespace              = var.namespace
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -3,7 +3,6 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -61,14 +61,6 @@ object({
 
 Default: `null`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -99,7 +91,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.1.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -107,15 +99,7 @@ Description: SSL certificate issuer to use. Usually you would configure this val
 
 Type: `string`
 
-Default: `"ca-issuer"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"kube-prometheus-stack"`
+Default: `"selfsigned-issuer"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -284,12 +268,6 @@ object({
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -311,19 +289,13 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.1.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 |`string`
-|`"ca-issuer"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"kube-prometheus-stack"`
+|`"selfsigned-issuer"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -9,7 +9,6 @@ module "kube-prometheus-stack" {
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
-  namespace              = var.namespace
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -3,7 +3,6 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/locals.tf
+++ b/locals.tf
@@ -197,7 +197,7 @@ locals {
             auth_url                 = "${replace(local.grafana.oidc.oauth_url, "\"", "\\\"")}"
             token_url                = "${replace(local.grafana.oidc.token_url, "\"", "\\\"")}"
             api_url                  = "${replace(local.grafana.oidc.api_url, "\"", "\\\"")}"
-            tls_skip_verify_insecure = var.cluster_issuer == "ca-issuer" || var.cluster_issuer == "letsencrypt-staging"
+            tls_skip_verify_insecure = var.cluster_issuer != "letsencrypt-prod"
           }, local.grafana.generic_oauth_extra_args)
           users = {
             auto_assign_org_role = "Editor"

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "argocd_project" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "kube-prometheus-stack"
     }
 
     # This extra destination block is needed by the v1/Service
@@ -43,7 +43,7 @@ resource "argocd_project" "this" {
 
 resource "kubernetes_namespace" "kube_prometheus_stack_namespace" {
   metadata {
-    name = var.namespace
+    name = "kube-prometheus-stack"
   }
 
   depends_on = [
@@ -57,7 +57,7 @@ resource "kubernetes_secret" "thanos_object_storage_secret" {
 
   metadata {
     name      = "thanos-objectstorage"
-    namespace = var.namespace
+    namespace = "kube-prometheus-stack"
   }
 
   data = {
@@ -115,7 +115,7 @@ resource "argocd_application" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "kube-prometheus-stack"
     }
 
     sync_policy {

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,7 @@ resource "argocd_project" "this" {
 
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "kube-prometheus-stack-${var.destination_cluster}" : "kube-prometheus-stack"
-    namespace = var.argocd_namespace
-    annotations = {
-      "devops-stack.io/argocd_namespace" = var.argocd_namespace
-    }
+    namespace = "argocd"
   }
 
   spec {
@@ -83,7 +80,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "kube-prometheus-stack-${var.destination_cluster}" : "kube-prometheus-stack"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "kube-prometheus-stack"
       "cluster"     = var.destination_cluster

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,10 @@ resource "kubernetes_namespace" "kube_prometheus_stack_namespace" {
   metadata {
     name = var.namespace
   }
+
+  depends_on = [
+    resource.null_resource.dependencies,
+  ]
 }
 
 
@@ -61,6 +65,7 @@ resource "kubernetes_secret" "thanos_object_storage_secret" {
   }
 
   depends_on = [
+    resource.null_resource.dependencies,
     resource.kubernetes_namespace.kube_prometheus_stack_namespace
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,10 @@ resource "argocd_application" "this" {
       plugin {
         name = "kustomized-helm"
         env {
+          name  = "HELM_ARGS"
+          value = "--name-template kube-prometheus-stack"
+        }
+        env {
           name  = "HELM_VALUES"
           value = data.utils_deep_merge_yaml.values.output
         }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -202,14 +202,6 @@ object({
 
 Default: `null`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -240,7 +232,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.1.0"`
+Default: `"v8.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -248,15 +240,7 @@ Description: SSL certificate issuer to use. Usually you would configure this val
 
 Type: `string`
 
-Default: `"ca-issuer"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"kube-prometheus-stack"`
+Default: `"selfsigned-issuer"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -430,12 +414,6 @@ object({
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -457,19 +435,13 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.1.0"`
+|`"v8.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 |`string`
-|`"ca-issuer"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"kube-prometheus-stack"`
+|`"selfsigned-issuer"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -9,7 +9,6 @@ module "kube-prometheus-stack" {
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
-  namespace              = var.namespace
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -3,7 +3,6 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/variables.tf
+++ b/variables.tf
@@ -12,12 +12,6 @@ variable "base_domain" {
   type        = string
 }
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-  default     = "argocd"
-}
-
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -48,12 +48,6 @@ variable "cluster_issuer" {
   default     = "selfsigned-issuer"
 }
 
-variable "namespace" {
-  description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
-  type        = string
-  default     = "kube-prometheus-stack"
-}
-
 variable "helm_values" {
   description = "Helm chart value overrides. They should be passed as a list of HCL structures."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "target_revision" {
 variable "cluster_issuer" {
   description = "SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files."
   type        = string
-  default     = "ca-issuer"
+  default     = "selfsigned-issuer"
 }
 
 variable "namespace" {


### PR DESCRIPTION
## Description of the changes

The main changes of this PR are the following:

- **fix!: hardcode the release name to remove the destination cluster**

  I found out that Argo CD passes the name of the application as a value to set the Helm chart. This means that all the templating that used `{ $.Release.Name }` would resolve to the name given to Argo CD application.

  In a multicluster deployment, using a single Argo CD, the names of the applications must be different. We solved that by appending the cluster name to the default application name when deploying on different clusters than `in-cluster`. However, this resulted in multiple problems for deployments that depended on the name of the application being static, so this solves that.

  This is a breaking change because sometimes this requires an application to be deleted and recreated.

- **fix!: remove the namespace variable**

  We found out that on multiple modules we were referencing resources from other modules using their default namespaces and this was hardcoded. In case someone decided to change the namespace of deployment of a certain application, this could break the way modules work with each other.

  We've decided that in order to avoid undefined behaviors caused by overloading this variable, it would be best to remove it entirely.

- **fix!: remove the ArgoCD namespace variable**

  Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

- Change the default cluster issuer to the one that is in fact always created by the cert-manager module.

- In line with the previous change, change the condition to disable the SSL verification on the OIDC to also include the `selfsigned-issuer`.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): because of the removal of the `namespace` and `argocd_namespace` variables and the fact that overloading the release name can force a recreation of the application.

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)