### PR TITLE
feat: add a subdomain variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,13 +40,13 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
-
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -82,6 +82,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -112,7 +120,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -257,11 +265,11 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -297,6 +305,12 @@ Description: The admin password for Grafana.
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -318,7 +332,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -40,13 +40,13 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Resources
 
@@ -265,11 +265,11 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -38,15 +38,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
 - [[provider_null]] <<provider_null,null>> (>= 3)
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Resources
 
@@ -84,7 +84,7 @@ The following input variables are optional (have default values):
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -265,11 +265,11 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources
@@ -306,7 +306,7 @@ Description: The admin password for Grafana.
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/README.adoc
+++ b/README.adoc
@@ -40,13 +40,13 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Resources
 
@@ -265,11 +265,11 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -77,7 +77,7 @@ Default: `null`
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -309,7 +309,7 @@ object({
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -75,6 +75,14 @@ object({
 
 Default: `null`
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -105,7 +113,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -300,6 +308,12 @@ object({
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -321,7 +335,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -32,6 +32,7 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
@@ -49,4 +50,3 @@ module "kube-prometheus-stack" {
 
   helm_values = concat(local.helm_values, var.helm_values)
 }
-

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -59,6 +59,14 @@ object({
 
 Default: `null`
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -89,7 +97,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -264,6 +272,12 @@ object({
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -285,7 +299,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -61,7 +61,7 @@ Default: `null`
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -273,7 +273,7 @@ object({
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -3,6 +3,7 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -61,6 +61,14 @@ object({
 
 Default: `null`
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -91,7 +99,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -268,6 +276,12 @@ object({
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -289,7 +303,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -63,7 +63,7 @@ Default: `null`
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -277,7 +277,7 @@ object({
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -3,6 +3,7 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/locals.tf
+++ b/locals.tf
@@ -7,7 +7,6 @@ locals {
   ingress_annotations = {
     "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
     "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-    "traefik.ingress.kubernetes.io/router.middlewares" = "traefik-withclustername@kubernetescrd"
     "traefik.ingress.kubernetes.io/router.tls"         = "true"
     "ingress.kubernetes.io/ssl-redirect"               = "true"
     "kubernetes.io/ingress.allow-http"                 = "false"

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,8 @@
 locals {
   oauth2_proxy_image       = "quay.io/oauth2-proxy/oauth2-proxy:v7.5.0"
   curl_wait_for_oidc_image = "curlimages/curl:8.3.0"
+  domain                   = trimprefix("${var.subdomain}.${var.base_domain}", ".")
+  domain_full              = trimprefix("${var.subdomain}.${var.cluster_name}.${var.base_domain}", ".")
 
   ingress_annotations = {
     "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
@@ -15,7 +17,7 @@ locals {
     enabled                  = true
     additional_data_sources  = false
     generic_oauth_extra_args = {}
-    domain                   = "grafana.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
+    domain                   = "grafana.${local.domain_full}"
     admin_password           = random_password.grafana_admin_password.result
   }
 
@@ -26,7 +28,7 @@ locals {
 
   prometheus_defaults = {
     enabled = true
-    domain  = "prometheus.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
+    domain  = "prometheus.${local.domain_full}"
   }
 
   prometheus = merge(
@@ -36,7 +38,7 @@ locals {
 
   alertmanager_defaults = {
     enabled            = true
-    domain             = "alertmanager.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
+    domain             = "alertmanager.${local.domain_full}"
     deadmanssnitch_url = null
     slack_routes       = []
   }
@@ -156,14 +158,14 @@ locals {
           servicePort = "9095"
           hosts = [
             "${local.alertmanager.domain}",
-            "alertmanager.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}"
+            "alertmanager.${local.domain}"
           ]
           tls = [
             {
               secretName = "alertmanager-tls"
               hosts = [
                 "${local.alertmanager.domain}",
-                "alertmanager.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
+                "alertmanager.${local.domain}",
               ]
             },
           ]
@@ -237,14 +239,14 @@ locals {
           annotations = local.ingress_annotations
           hosts = [
             "${local.grafana.domain}",
-            "grafana.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
+            "grafana.${local.domain}",
           ]
           tls = [
             {
               secretName = "grafana-tls"
               hosts = [
                 "${local.grafana.domain}",
-                "grafana.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
+                "grafana.${local.domain}",
               ]
             },
           ]
@@ -288,14 +290,14 @@ locals {
           servicePort = "9091"
           hosts = [
             "${local.prometheus.domain}",
-            "prometheus.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
+            "prometheus.${local.domain}",
           ]
           tls = [
             {
               secretName = "prometheus-tls"
               hosts = [
                 "${local.prometheus.domain}",
-                "prometheus.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
+                "prometheus.${local.domain}",
               ]
             },
           ]

--- a/locals.tf
+++ b/locals.tf
@@ -15,7 +15,7 @@ locals {
     enabled                  = true
     additional_data_sources  = false
     generic_oauth_extra_args = {}
-    domain                   = "grafana.apps.${var.cluster_name}.${var.base_domain}"
+    domain                   = "grafana.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
     admin_password           = random_password.grafana_admin_password.result
   }
 
@@ -26,7 +26,7 @@ locals {
 
   prometheus_defaults = {
     enabled = true
-    domain  = "prometheus.apps.${var.cluster_name}.${var.base_domain}"
+    domain  = "prometheus.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
   }
 
   prometheus = merge(
@@ -36,7 +36,7 @@ locals {
 
   alertmanager_defaults = {
     enabled            = true
-    domain             = "alertmanager.apps.${var.cluster_name}.${var.base_domain}"
+    domain             = "alertmanager.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
     deadmanssnitch_url = null
     slack_routes       = []
   }
@@ -156,14 +156,14 @@ locals {
           servicePort = "9095"
           hosts = [
             "${local.alertmanager.domain}",
-            "alertmanager.apps.${var.base_domain}"
+            "alertmanager.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}"
           ]
           tls = [
             {
               secretName = "alertmanager-tls"
               hosts = [
                 "${local.alertmanager.domain}",
-                "alertmanager.apps.${var.base_domain}",
+                "alertmanager.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
               ]
             },
           ]
@@ -237,14 +237,14 @@ locals {
           annotations = local.ingress_annotations
           hosts = [
             "${local.grafana.domain}",
-            "grafana.apps.${var.base_domain}",
+            "grafana.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
           ]
           tls = [
             {
               secretName = "grafana-tls"
               hosts = [
                 "${local.grafana.domain}",
-                "grafana.apps.${var.base_domain}",
+                "grafana.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
               ]
             },
           ]
@@ -288,14 +288,14 @@ locals {
           servicePort = "9091"
           hosts = [
             "${local.prometheus.domain}",
-            "prometheus.apps.${var.base_domain}",
+            "prometheus.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
           ]
           tls = [
             {
               secretName = "prometheus-tls"
               hosts = [
                 "${local.prometheus.domain}",
-                "prometheus.apps.${var.base_domain}",
+                "prometheus.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
               ]
             },
           ]

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -204,7 +204,7 @@ Default: `null`
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -423,7 +423,7 @@ object({
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -202,6 +202,14 @@ object({
 
 Default: `null`
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -232,7 +240,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -414,6 +422,12 @@ object({
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -435,7 +449,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -3,6 +3,7 @@ module "kube-prometheus-stack" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "base_domain" {
   type        = string
 }
 
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
+}
+
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -13,9 +13,10 @@ variable "base_domain" {
 }
 
 variable "subdomain" {
-  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  description = "Subdomain of the cluster. Value used for the ingress' URL of the application."
   type        = string
   default     = "apps"
+  nullable    = false
 }
 
 variable "argocd_project" {


### PR DESCRIPTION
## Description of the changes

Hello,

We have a need to use URLs without the .apps. part, in order to achieve that without introducing a breaking change we propose a new variable subdomain that defaults to apps, that way we can set it to an empty string on our side.

## Breaking change

- [x] No


## Tests executed on which distribution(s)

- [x] KinD
- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)