### PR TITLE
feat: enable the export of Thanos sidecar metrics

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,15 +38,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -112,7 +112,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.2.0"`
+Default: `"v9.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -318,7 +318,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.2.0"`
+|`"v9.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -105,7 +105,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.2.0"`
+Default: `"v9.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -321,7 +321,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.2.0"`
+|`"v9.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -89,7 +89,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.2.0"`
+Default: `"v9.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -285,7 +285,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.2.0"`
+|`"v9.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -91,7 +91,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.2.0"`
+Default: `"v9.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -289,7 +289,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.2.0"`
+|`"v9.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/locals.tf
+++ b/locals.tf
@@ -374,6 +374,9 @@ locals {
         thanosService = {
           enabled = var.metrics_storage_main != null ? true : false
         }
+        thanosServiceMonitor = {
+          enabled = var.metrics_storage_main != null ? true : false
+        }
         }
       )
     }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -232,7 +232,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v8.2.0"`
+Default: `"v9.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -435,7 +435,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v8.2.0"`
+|`"v9.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>


### PR DESCRIPTION
## Description of the changes

This PR enables the export of metrics for the Thanos sidecar, when it is enabled. This is required and relates to the PR https://github.com/camptocamp/devops-stack-module-thanos/pull/73 on the Thanos module.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)