### PR TITLE
feat: add a variable to set resources and upgrade OAuth Proxy and curl images

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,11 +38,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
-
-- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
@@ -178,6 +178,99 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+Default: `{}`
+
 ==== [[input_grafana]] <<input_grafana,grafana>>
 
 Description: Grafana settings
@@ -215,7 +308,7 @@ Default: `{}`
 
 ==== [[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
 
-Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 
 Type: `any`
 
@@ -385,6 +478,100 @@ object({
 |`{}`
 |no
 
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+|`{}`
+|no
+
 |[[input_grafana]] <<input_grafana,grafana>>
 |Grafana settings
 |`any`
@@ -416,7 +603,7 @@ object({
 |no
 
 |[[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
-|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 |`any`
 |`{}`
 |no

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -171,6 +171,99 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+Default: `{}`
+
 ==== [[input_grafana]] <<input_grafana,grafana>>
 
 Description: Grafana settings
@@ -208,7 +301,7 @@ Default: `{}`
 
 ==== [[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
 
-Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 
 Type: `any`
 
@@ -388,6 +481,100 @@ object({
 |`{}`
 |no
 
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+|`{}`
+|no
+
 |[[input_grafana]] <<input_grafana,grafana>>
 |Grafana settings
 |`any`
@@ -419,7 +606,7 @@ object({
 |no
 
 |[[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
-|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 |`any`
 |`{}`
 |no

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -42,6 +42,8 @@ module "kube-prometheus-stack" {
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids
 
+  resources = var.resources
+
   prometheus   = var.prometheus
   alertmanager = var.alertmanager
   grafana      = var.grafana

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -155,6 +155,99 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+Default: `{}`
+
 ==== [[input_grafana]] <<input_grafana,grafana>>
 
 Description: Grafana settings
@@ -192,7 +285,7 @@ Default: `{}`
 
 ==== [[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
 
-Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 
 Type: `any`
 
@@ -352,6 +445,100 @@ object({
 |`{}`
 |no
 
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+|`{}`
+|no
+
 |[[input_grafana]] <<input_grafana,grafana>>
 |Grafana settings
 |`any`
@@ -383,7 +570,7 @@ object({
 |no
 
 |[[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
-|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 |`any`
 |`{}`
 |no

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -13,6 +13,8 @@ module "kube-prometheus-stack" {
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids
 
+  resources = var.resources
+
   prometheus   = var.prometheus
   alertmanager = var.alertmanager
   grafana      = var.grafana

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -157,6 +157,99 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+Default: `{}`
+
 ==== [[input_grafana]] <<input_grafana,grafana>>
 
 Description: Grafana settings
@@ -194,7 +287,7 @@ Default: `{}`
 
 ==== [[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
 
-Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 
 Type: `any`
 
@@ -356,6 +449,100 @@ object({
 |`{}`
 |no
 
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+|`{}`
+|no
+
 |[[input_grafana]] <<input_grafana,grafana>>
 |Grafana settings
 |`any`
@@ -387,7 +574,7 @@ object({
 |no
 
 |[[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
-|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 |`any`
 |`{}`
 |no

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -13,6 +13,8 @@ module "kube-prometheus-stack" {
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids
 
+  resources = var.resources
+
   prometheus   = var.prometheus
   alertmanager = var.alertmanager
   grafana      = var.grafana

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  oauth2_proxy_image       = "quay.io/oauth2-proxy/oauth2-proxy:v7.5.0"
+  oauth2_proxy_image       = "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
   curl_wait_for_oidc_image = "curlimages/curl:8.6.0"
   domain                   = trimprefix("${var.subdomain}.${var.base_domain}", ".")
   domain_full              = trimprefix("${var.subdomain}.${var.cluster_name}.${var.base_domain}", ".")

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -298,6 +298,99 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+Default: `{}`
+
 ==== [[input_grafana]] <<input_grafana,grafana>>
 
 Description: Grafana settings
@@ -335,7 +428,7 @@ Default: `{}`
 
 ==== [[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
 
-Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+Description: Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 
 Type: `any`
 
@@ -502,6 +595,100 @@ object({
 |`{}`
 |no
 
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+|`{}`
+|no
+
 |[[input_grafana]] <<input_grafana,grafana>>
 |Grafana settings
 |`any`
@@ -533,7 +720,7 @@ object({
 |no
 
 |[[input_metrics_storage_main]] <<input_metrics_storage_main,metrics_storage_main>>
-|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used.
+|Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used.
 |`any`
 |`{}`
 |no

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -13,6 +13,8 @@ module "kube-prometheus-stack" {
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids
 
+  resources = var.resources
+
   prometheus   = var.prometheus
   alertmanager = var.alertmanager
   grafana      = var.grafana

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,95 @@ variable "dependency_ids" {
 ## Module variables
 #######################
 
+variable "resources" {
+  description = <<-EOT
+    Resource limits and requests for kube-prometheus-stack's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+    IMPORTANT: These are not production values. You should always adjust them to your needs.
+  EOT
+  type = object({
+
+    prometheus = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "1024Mi")
+      }), {})
+    }), {})
+
+    prometheus_operator = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    thanos_sidecar = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    alertmanager = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    kube_state_metrics = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    grafana = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    node_exporter = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+  default = {}
+}
+
 variable "grafana" {
   description = "Grafana settings"
   type        = any
@@ -116,7 +205,7 @@ variable "alertmanager" {
 }
 
 variable "metrics_storage_main" {
-  description = "Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the provider used."
+  description = "Storage settings for the Thanos sidecar. Needs to be of type `any` because the structure is different depending on the variant used."
   type        = any
   default     = {}
 }


### PR DESCRIPTION
## Description of the changes

This PR adds a variable to set resources' limits and requests on the module components.

Having default values is good practice to prevent that our components could eventually starve other workloads on the cluster. However, these should probably be adapted in production clusters and are only a safeguard in case someone forgets to set them.

It also upgrades the images of OAuth Proxy and curl, which are used for authenticating to the services of the kube-prometheus-stack.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)