### PR TITLE
feat(eks)!: add option to create IAM role for the metrics storage

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,7 +120,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v10.1.0"`
+Default: `"v10.1.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -358,10 +358,10 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
@@ -425,7 +425,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v10.1.0"`
+|`"v10.1.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -118,7 +118,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v10.1.0"`
+Default: `"v10.1.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -437,7 +437,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v10.1.0"`
+|`"v10.1.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -13,15 +13,35 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
+=== Providers
+
+The following providers are used by this module:
+
+- [[provider_aws]] <<provider_aws,aws>>
+
 === Modules
 
 The following Modules are called:
+
+==== [[module_iam_assumable_role_kube_prometheus_stack]] <<module_iam_assumable_role_kube_prometheus_stack,iam_assumable_role_kube_prometheus_stack>>
+
+Source: terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc
+
+Version: ~> 5.0
 
 ==== [[module_kube-prometheus-stack]] <<module_kube-prometheus-stack,kube-prometheus-stack>>
 
 Source: ../
 
 Version:
+
+=== Resources
+
+The following resources are used by this module:
+
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy[aws_iam_policy.kube_prometheus_stack] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document[aws_iam_policy_document.kube_prometheus_stack] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket[aws_s3_bucket.kube_prometheus_stack] (data source)
 
 === Required Inputs
 
@@ -51,9 +71,10 @@ Type:
 [source,hcl]
 ----
 object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
 ----
 
@@ -97,7 +118,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v10.1.0"`
+Default: `"v10.1.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -324,12 +345,31 @@ Description: The admin password for Grafana.
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
+= Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_aws]] <<provider_aws,aws>> |n/a
+|===
+
 = Modules
 
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
+|[[module_iam_assumable_role_kube_prometheus_stack]] <<module_iam_assumable_role_kube_prometheus_stack,iam_assumable_role_kube_prometheus_stack>> |terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc |~> 5.0
 |[[module_kube-prometheus-stack]] <<module_kube-prometheus-stack,kube-prometheus-stack>> |../ |
+|===
+
+= Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy[aws_iam_policy.kube_prometheus_stack] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document[aws_iam_policy_document.kube_prometheus_stack] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket[aws_s3_bucket.kube_prometheus_stack] |data source
 |===
 
 = Inputs
@@ -344,9 +384,10 @@ Description: The admin password for Grafana.
 [source]
 ----
 object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
 ----
 
@@ -392,7 +433,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v10.1.0"`
+|`"v10.1.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/extra-variables.tf
+++ b/eks/extra-variables.tf
@@ -1,9 +1,18 @@
 variable "metrics_storage" {
   description = "AWS S3 bucket configuration values for the bucket where the archived metrics will be stored."
   type = object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
+
   default = null
+
+  validation {
+    # We use the try() function to avoid errors here when we deactivate the metrics storage by setting the 
+    # `metrics_storage` variable to `null`.
+    condition     = try(var.metrics_storage.create_role ? var.metrics_storage.cluster_oidc_issuer_url != null : var.metrics_storage.iam_role_arn != null, true)
+    error_message = "If you want to create a role, you need to provide the OIDC issuer's URL for the EKS cluster. Otherwise, you need to provide the ARN of the IAM role you created."
+  }
 }

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,10 +1,14 @@
 locals {
+  # We use the try() function to avoid errors here when we deactivate the metrics storage by setting the 
+  # `metrics_storage` variable to `null`.
+  iam_role_arn = try(var.metrics_storage.create_role ? module.iam_assumable_role_kube_prometheus_stack.iam_role_arn : var.metrics_storage.iam_role_arn, null)
+
   metrics_storage = var.metrics_storage != null ? {
     storage_config = {
       type = "s3"
       config = {
-        bucket   = "${var.metrics_storage.bucket_id}"
-        endpoint = "s3.${var.metrics_storage.region}.amazonaws.com"
+        bucket   = "${data.aws_s3_bucket.kube_prometheus_stack[0].id}"
+        endpoint = "s3.${data.aws_s3_bucket.kube_prometheus_stack[0].region}.amazonaws.com"
       }
     }
   } : null
@@ -14,7 +18,7 @@ locals {
       prometheus = {
         serviceAccount = {
           annotations = {
-            "eks.amazonaws.com/role-arn" = var.metrics_storage.iam_role_arn
+            "eks.amazonaws.com/role-arn" = local.iam_role_arn
           }
         }
       }

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,3 +1,56 @@
+data "aws_s3_bucket" "kube_prometheus_stack" {
+  count = var.metrics_storage != null ? 1 : 0
+
+  bucket = var.metrics_storage.bucket_id
+}
+
+data "aws_iam_policy_document" "kube_prometheus_stack" {
+  count = var.metrics_storage != null ? (var.metrics_storage.create_role ? 1 : 0) : 0
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      data.aws_s3_bucket.kube_prometheus_stack[0].arn,
+      format("%s/*", data.aws_s3_bucket.kube_prometheus_stack[0].arn),
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "kube_prometheus_stack" {
+  count = var.metrics_storage != null ? (var.metrics_storage.create_role ? 1 : 0) : 0
+
+  name        = "kube-prometheus-stack-s3"
+  description = "IAM policy for the kube-prometheus-stack to access the S3 bucket named ${data.aws_s3_bucket.kube_prometheus_stack[0].id}"
+  policy      = data.aws_iam_policy_document.kube_prometheus_stack[0].json
+}
+
+module "iam_assumable_role_kube_prometheus_stack" {
+  source                     = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                    = "~> 5.0"
+  create_role                = var.metrics_storage != null ? var.metrics_storage.create_role : false
+  number_of_role_policy_arns = 1
+  role_name_prefix           = "kube-prometheus-stack-s3-"
+
+  # We use the try() function to avoid errors here when we deactivate the metrics storage by setting the 
+  # `metrics_storage` variable to `null`.
+  provider_url     = try(trimprefix(var.metrics_storage.cluster_oidc_issuer_url, "https://"), "")
+  role_policy_arns = [try(resource.aws_iam_policy.kube_prometheus_stack[0].arn, null)]
+
+  # List of ServiceAccounts that have permission to attach to this IAM role
+  oidc_fully_qualified_subjects = [
+    "system:serviceaccount:kube-prometheus-stack:kube-prometheus-stack-prometheus"
+  ]
+}
+
 module "kube-prometheus-stack" {
   source = "../"
 

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -99,7 +99,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v10.1.0"`
+Default: `"v10.1.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -396,7 +396,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v10.1.0"`
+|`"v10.1.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -240,7 +240,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v10.1.0"`
+Default: `"v10.1.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -542,7 +542,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v10.1.0"`
+|`"v10.1.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>


### PR DESCRIPTION
## Description of the changes

This commit solves ISDEVOPS-279 and ISDEVOPS-283 for the EKS variant. That is, it adds support for creating the IAM role automatically inside the modules while also giving the chance to provide a custom one managed by the user.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes - because the Terraform variable was changed

## Tests executed on which distribution(s)

- [x] EKS (AWS)