### PR TITLE
feat: add Runbook URL on alertmanager template

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,13 +40,13 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -358,10 +358,10 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 

--- a/locals.tf
+++ b/locals.tf
@@ -94,24 +94,27 @@ locals {
 
   alertmanager_template_files = length(local.alertmanager.slack_routes) > 0 ? {
     "slack.tmpl" = <<-EOT
-      {{ define "slack.title" -}}
-        [{{ .Status | toUpper }}
-        {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
-        ] {{ .CommonLabels.alertname }}
-      {{ end }}
-      {{ define "slack.text" -}}
-      {{ range .Alerts }}
-        *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
-        {{- if .Annotations.description }}
-        *Severity:* `{{ .Labels.severity }}`
-        *Description:* {{ .Annotations.description }}
-        {{- end }}
-        *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:>
-        *Labels:*
-          {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
-          {{ end }}
-      {{ end }}
-      {{ end }}
+        {{ define "slack.title" -}}
+          [{{ .Status | toUpper }}
+          {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
+          ] {{ .CommonLabels.alertname }}
+        {{ end }}
+        {{ define "slack.text" -}}
+        {{ range .Alerts }}
+          *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
+          {{- if .Annotations.description }}
+          *Severity:* `{{ .Labels.severity }}`
+          *Description:* {{ .Annotations.description }}
+          {{- end }}
+          *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:>
+          *Labels:*
+            {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
+            {{ end }}
+          {{- if .Annotations.runbook_url }}
+          *Runbook URL:* <{{ .Annotations.runbook_url }}|Click here>
+          {{- end }}
+        {{ end }}
+        {{ end }}
     EOT
   } : {}
 


### PR DESCRIPTION
## Description of the changes

This PR adds a runbook URL to the alert templates sent to Slack, which is useful for debugging purposes. It includes a URL that redirects to documentation detailing the alerts. We have implemented this feature in our Shelter module, and I believe it would be beneficial to include it in the kube-prometheus-stack module as well.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)