### PR TITLE
fix(eks): use name_prefix instead of name when creating a IAM policy

### DIFF
--- a/eks/main.tf
+++ b/eks/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "kube_prometheus_stack" {
 resource "aws_iam_policy" "kube_prometheus_stack" {
   count = var.metrics_storage != null ? (var.metrics_storage.create_role ? 1 : 0) : 0
 
-  name        = "kube-prometheus-stack-s3"
+  name_prefix = "kube-prometheus-stack-s3-"
   description = "IAM policy for the kube-prometheus-stack to access the S3 bucket named ${data.aws_s3_bucket.kube_prometheus_stack[0].id}"
   policy      = data.aws_iam_policy_document.kube_prometheus_stack[0].json
 }


### PR DESCRIPTION
## Description of the changes

This PR fixes an error that prevents having multiple DevOps Stack deployments on the same AWS role. This was already the standard on the other DevOps Stack modules.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)