### PR TITLE
Slack templates improvements proposal

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -94,27 +94,30 @@ locals {
 
   alertmanager_template_files = length(local.alertmanager.slack_routes) > 0 ? {
     "slack.tmpl" = <<-EOT
-        {{ define "slack.title" -}}
-          [{{ .Status | toUpper }}
-          {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
-          ] {{ .CommonLabels.alertname }}
+      {{ define "slack.title" -}}
+        [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+      {{ end }}
+
+      {{ define "slack.text" -}}
+        {{ with index .Alerts 0 -}}
+          :chart_with_upwards_trend: *<{{ .GeneratorURL }}|Source Graph>*
         {{ end }}
-        {{ define "slack.text" -}}
-        {{ range .Alerts }}
-          *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
-          {{- if .Annotations.description }}
-          *Severity:* `{{ .Labels.severity }}`
-          *Description:* {{ .Annotations.description }}
-          {{- end }}
-          *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:>
-          *Labels:*
-            {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
-            {{ end }}
-          {{- if .Annotations.runbook_url }}
-          *Runbook URL:* <{{ .Annotations.runbook_url }}|Click here>
-          {{- end }}
+        {{- range .Alerts -}}
+        *Severity:* `{{ .Labels.severity }}`
+        {{- if .Annotations.summary }}
+        *Alert:* {{ .Annotations.summary }}
+        {{- end }}
+        {{- if .Annotations.description }}
+        *Description:* {{ .Annotations.description }}
+        {{- end }}
+        {{- if .Annotations.runbook_url }}
+        *Runbook URL:* <{{ .Annotations.runbook_url }}|Click here>
+        {{- end }}
+        *Labels:*
+          {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+          {{ end }}
         {{ end }}
-        {{ end }}
+      {{ end }}
     EOT
   } : {}
 


### PR DESCRIPTION
## Description of the changes

Hello, I would like to propose some improvements in the alertmanager slack templates :

- Do not split the notification title on two lines
- Put the chart above the loop on alerts (since they are grouped its the same each time anyway)
- Do not put "severity" in the "if .Annotations.description" block
- Put the runbook_url above the labels list (or else its truncated by slack most times)

## Breaking change

- [X] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [X] KinD
- [ ] AKS (Azure)
- [X] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)