### PR TITLE
fix(aks): add merge() to avoid null value that breaks values generation

### DIFF
--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -16,7 +16,7 @@ locals {
 
   helm_values = [{
     kube-prometheus-stack = {
-      prometheus = local.use_managed_identity ? {
+      prometheus = merge(local.use_managed_identity ? {
         serviceAccount = {
           annotations = {
             "azure.workload.identity/client-id" = resource.azurerm_user_assigned_identity.prometheus[0].client_id
@@ -29,7 +29,7 @@ locals {
             }
           }
         }
-      } : null
+      } : null, {})
     }
   }]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   oauth2_proxy_image       = "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
-  curl_wait_for_oidc_image = "curlimages/curl:8.6.0"
+  curl_wait_for_oidc_image = "quay.io/curl/curl:8.10.1"
   domain                   = trimprefix("${var.subdomain}.${var.base_domain}", ".")
   domain_full              = trimprefix("${var.subdomain}.${var.cluster_name}.${var.base_domain}", ".")
 


### PR DESCRIPTION
## Description of the changes

This PR fixes an issue in AKS deployments when NOT using managed identities to configure the metrics storage. When that was the case, the value for the key `kube-prometheus-stack.prometheus` was `null` and that prevented merging the values that came from the `helm_values` variable.

We also changed the registry for the `curl` image in order to avoid the strict rate-limits from Docker Hub.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)