### PR TITLE
feat: add distinct to avoid duplicates in ingreses hosts lists

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,7 +120,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v13.0.0"`
+Default: `"v14.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -358,10 +358,10 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
+|[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
@@ -425,7 +425,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v13.0.0"`
+|`"v14.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -118,7 +118,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v13.0.0"`
+Default: `"v14.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -437,7 +437,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v13.0.0"`
+|`"v14.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -118,7 +118,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v13.0.0"`
+Default: `"v14.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -433,7 +433,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v13.0.0"`
+|`"v14.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -99,7 +99,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v13.0.0"`
+Default: `"v14.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -396,7 +396,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v13.0.0"`
+|`"v14.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/locals.tf
+++ b/locals.tf
@@ -174,17 +174,17 @@ locals {
           enabled     = true
           annotations = local.ingress_annotations
           servicePort = "9095"
-          hosts = [
+          hosts = distinct([
             "${local.alertmanager.domain}",
             "alertmanager.${local.domain}"
-          ]
+          ])
           tls = [
             {
               secretName = "alertmanager-tls"
-              hosts = [
+              hosts = distinct([
                 "${local.alertmanager.domain}",
                 "alertmanager.${local.domain}",
-              ]
+              ])
             },
           ]
         }
@@ -259,17 +259,17 @@ locals {
         ingress = {
           enabled     = true
           annotations = local.ingress_annotations
-          hosts = [
+          hosts = distinct([
             "${local.grafana.domain}",
             "grafana.${local.domain}",
-          ]
+          ])
           tls = [
             {
               secretName = "grafana-tls"
-              hosts = [
+              hosts = distinct([
                 "${local.grafana.domain}",
                 "grafana.${local.domain}",
-              ]
+              ])
             },
           ]
         }
@@ -314,17 +314,17 @@ locals {
           enabled     = true
           annotations = local.ingress_annotations
           servicePort = "9091"
-          hosts = [
+          hosts = distinct([
             "${local.prometheus.domain}",
             "prometheus.${local.domain}",
-          ]
+          ])
           tls = [
             {
               secretName = "prometheus-tls"
-              hosts = [
+              hosts = distinct([
                 "${local.prometheus.domain}",
                 "prometheus.${local.domain}",
-              ]
+              ])
             },
           ]
         }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -240,7 +240,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v13.0.0"`
+Default: `"v14.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -542,7 +542,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v13.0.0"`
+|`"v14.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>


### PR DESCRIPTION
## Description of the changes

We don't use a cluster.name in our URLs (the platform is unique and upgraded in place)
So the ingresses were configured with two identical tls hosts, which was firing alerts about duplicate time series and so on.

I added a distinct() so that in our case we have just one host in the end and that the current stacks are not impacted.

## Breaking change

- [X] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [X] KinD