### PR TITLE
feat: add pvc for alertmanager data

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,15 +38,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 6)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -120,7 +120,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v14.0.0"`
+Default: `"v14.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -322,6 +322,14 @@ Type: `number`
 
 Default: `30`
 
+==== [[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+
+Description: Default PVC size for Alertmanager data.
+
+Type: `string`
+
+Default: `"10Gi"`
+
 === Outputs
 
 The following outputs are exported:
@@ -358,11 +366,11 @@ Description: The admin password for Grafana.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -425,7 +433,7 @@ Description: The admin password for Grafana.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v14.0.0"`
+|`"v14.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -612,6 +620,12 @@ object({
 |Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
+|no
+
+|[[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+|Default PVC size for Alertmanager data.
+|`string`
+|`"10Gi"`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -118,7 +118,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v14.0.0"`
+Default: `"v14.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -320,6 +320,14 @@ Type: `number`
 
 Default: `30`
 
+==== [[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+
+Description: Default PVC size for Alertmanager data.
+
+Type: `string`
+
+Default: `"10Gi"`
+
 === Outputs
 
 The following outputs are exported:
@@ -437,7 +445,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v14.0.0"`
+|`"v14.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -624,6 +632,12 @@ object({
 |Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
+|no
+
+|[[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+|Default PVC size for Alertmanager data.
+|`string`
+|`"10Gi"`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -118,7 +118,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v14.0.0"`
+Default: `"v14.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -320,6 +320,14 @@ Type: `number`
 
 Default: `30`
 
+==== [[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+
+Description: Default PVC size for Alertmanager data.
+
+Type: `string`
+
+Default: `"10Gi"`
+
 === Outputs
 
 The following outputs are exported:
@@ -433,7 +441,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v14.0.0"`
+|`"v14.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -620,6 +628,12 @@ object({
 |Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
+|no
+
+|[[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+|Default PVC size for Alertmanager data.
+|`string`
+|`"10Gi"`
 |no
 
 |===

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -99,7 +99,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v14.0.0"`
+Default: `"v14.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -301,6 +301,14 @@ Type: `number`
 
 Default: `30`
 
+==== [[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+
+Description: Default PVC size for Alertmanager data.
+
+Type: `string`
+
+Default: `"10Gi"`
+
 === Outputs
 
 The following outputs are exported:
@@ -396,7 +404,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v14.0.0"`
+|`"v14.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -583,6 +591,12 @@ object({
 |Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
+|no
+
+|[[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+|Default PVC size for Alertmanager data.
+|`string`
+|`"10Gi"`
 |no
 
 |===

--- a/locals.tf
+++ b/locals.tf
@@ -169,6 +169,18 @@ locals {
             requests = { for k, v in var.resources.alertmanager.requests : k => v if v != null }
             limits   = { for k, v in var.resources.alertmanager.limits : k => v if v != null }
           }
+          storage = {
+            volumeClaimTemplate = {
+              spec = {
+                accessModes = ["ReadWriteOnce"]
+                resources = {
+                  requests = {
+                    storage = var.alertmanager_storage_size
+                  }
+                }
+              }
+            }
+          }
         }
         ingress = {
           enabled     = true

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -240,7 +240,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v14.0.0"`
+Default: `"v14.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -442,6 +442,14 @@ Type: `number`
 
 Default: `30`
 
+==== [[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+
+Description: Default PVC size for Alertmanager data.
+
+Type: `string`
+
+Default: `"10Gi"`
+
 === Outputs
 
 The following outputs are exported:
@@ -542,7 +550,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v14.0.0"`
+|`"v14.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -729,6 +737,12 @@ object({
 |Variable to set the time when a query times out. This applies to all the Grafana's data sources and can be manually configured per data source if desired.
 |`number`
 |`30`
+|no
+
+|[[input_alertmanager_storage_size]] <<input_alertmanager_storage_size,alertmanager_storage_size>>
+|Default PVC size for Alertmanager data.
+|`string`
+|`"10Gi"`
 |no
 
 |===

--- a/variables.tf
+++ b/variables.tf
@@ -215,3 +215,9 @@ variable "dataproxy_timeout" {
   type        = number
   default     = 30
 }
+
+variable "alertmanager_storage_size" {
+  description = "Default PVC size for Alertmanager data."
+  type        = string
+  default     = "10Gi"
+}


### PR DESCRIPTION
## Description of the changes
Integrates a Persistent Volume Claim (PVC) to enable persistent storage for Alertmanager alerts. This ensures that alerts remain available across pod restarts and deployments, preventing loss of alert history and state.

## Breaking change

- [x] No
## Tests executed on which distribution(s)

- [x] AKS (Azure)